### PR TITLE
feat: fix bugs, add notifications, search, favorites & i18n

### DIFF
--- a/app/(home)/(private)/layout.tsx
+++ b/app/(home)/(private)/layout.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { redirect } from "next/navigation";
-import { toast } from "sonner";
 import { useSession } from "@/src/lib/auth-client";
 
 export default function AuthLayout({
@@ -9,10 +8,13 @@ export default function AuthLayout({
 }: {
 	children: React.ReactNode;
 }) {
-	const { data: session } = useSession();
+	const { data: session, isPending } = useSession();
+
+	if (isPending) {
+		return null;
+	}
 
 	if (!session) {
-		toast.error("You must be signed in to access this page.");
 		redirect("/sign-in");
 	}
 

--- a/app/(home)/(private)/notifications/page.tsx
+++ b/app/(home)/(private)/notifications/page.tsx
@@ -1,0 +1,74 @@
+import { Bell } from "lucide-react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { Layout } from "@/components/layouts/layout";
+import { markAllNotificationsRead } from "@/src/actions/notification.action";
+import { getSession } from "@/src/lib/auth-server";
+import { getNotifications } from "@/src/query/notification.query";
+
+function timeAgo(date: Date): string {
+	const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h`;
+	return `${Math.floor(hours / 24)}d`;
+}
+
+export default async function NotificationsPage() {
+	const session = await getSession();
+
+	if (!session?.user?.id) {
+		redirect("/sign-in");
+	}
+
+	const t = await getTranslations("notifications");
+	const notifications = await getNotifications(session.user.id);
+
+	await markAllNotificationsRead();
+
+	return (
+		<Layout>
+			<div className="py-4">
+				<h1 className="text-xl font-bold mb-6">{t("title")}</h1>
+
+				{notifications.length === 0 ? (
+					<div className="flex flex-col items-center justify-center gap-3 py-20 text-muted-foreground">
+						<Bell className="h-10 w-10" />
+						<p className="text-sm">{t("empty")}</p>
+					</div>
+				) : (
+					<div className="space-y-1">
+						{notifications.map((notif) => (
+							<div
+								key={notif.id}
+								className={`flex items-start gap-3 p-3 rounded-lg ${!notif.readAt ? "bg-accent/40" : ""}`}
+							>
+								<div className="flex-shrink-0 mt-0.5 w-8 h-8 rounded-full bg-muted flex items-center justify-center">
+									<Bell className="h-4 w-4 text-muted-foreground" />
+								</div>
+								<div className="flex-1 min-w-0">
+									{notif.link ? (
+										<Link
+											href={notif.link}
+											className="text-sm hover:underline line-clamp-2"
+										>
+											{notif.content}
+										</Link>
+									) : (
+										<p className="text-sm line-clamp-2">{notif.content}</p>
+									)}
+									<p className="text-xs text-muted-foreground mt-0.5">
+										{timeAgo(new Date(notif.createdAt))}
+									</p>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+		</Layout>
+	);
+}

--- a/app/(home)/(private)/notifications/page.tsx
+++ b/app/(home)/(private)/notifications/page.tsx
@@ -25,7 +25,7 @@ export default async function NotificationsPage() {
 	}
 
 	const t = await getTranslations("notifications");
-	const notifications = await getNotifications(session.user.id);
+	const notifications = await getNotifications();
 
 	await markAllNotificationsRead();
 
@@ -46,7 +46,7 @@ export default async function NotificationsPage() {
 								key={notif.id}
 								className={`flex items-start gap-3 p-3 rounded-lg ${!notif.readAt ? "bg-accent/40" : ""}`}
 							>
-								<div className="flex-shrink-0 mt-0.5 w-8 h-8 rounded-full bg-muted flex items-center justify-center">
+								<div className="shrink-0 mt-0.5 w-8 h-8 rounded-full bg-muted flex items-center justify-center">
 									<Bell className="h-4 w-4 text-muted-foreground" />
 								</div>
 								<div className="flex-1 min-w-0">

--- a/app/(home)/(private)/onboarding/onboarding-steps.tsx
+++ b/app/(home)/(private)/onboarding/onboarding-steps.tsx
@@ -33,6 +33,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import { saveOnboarding } from "./onboarding.action";
 
 const userTypeSchema = z.object({
 	userType: z.enum(["USER", "PLAYER", "COACH", "RECRUITER", "CLUB"] as const),
@@ -95,18 +96,12 @@ export function OnboardingSteps() {
 		data: PlayerInfoValues | CoachInfoValues | ClubInfoValues,
 	) => {
 		try {
-			const response = await fetch("/api/onboarding", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({
-					userType,
-					...data,
-				}),
+			const result = await saveOnboarding({
+				userType: userType as UserType,
+				...data,
 			});
 
-			if (!response.ok) throw new Error();
+			if (!result.success) throw new Error(result.error);
 
 			router.push("/feed");
 		} catch (error) {

--- a/app/(home)/(private)/onboarding/onboarding.action.ts
+++ b/app/(home)/(private)/onboarding/onboarding.action.ts
@@ -1,0 +1,90 @@
+"use server";
+
+import type { Foot, Position, UserType } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { getUserSessionId } from "@/src/query/user.query";
+
+const POSITION_MAP: Record<string, Position> = {
+	GOALKEEPER: "GOALKEEPER",
+	DEFENDER: "CENTRE_BACK",
+	MIDFIELDER: "CENTRE_MIDFIELDER",
+	FORWARD: "CENTRE_FORWARD",
+	CENTRE_BACK: "CENTRE_BACK",
+	RIGHT_BACK: "RIGHT_BACK",
+	LEFT_BACK: "LEFT_BACK",
+	DEFENSIVE_MIDFIELDER: "DEFENSIVE_MIDFIELDER",
+	CENTRE_MIDFIELDER: "CENTRE_MIDFIELDER",
+	ATTACKING_MIDFIELDER: "ATTACKING_MIDFIELDER",
+	RIGHT_WINGER: "RIGHT_WINGER",
+	LEFT_WINGER: "LEFT_WINGER",
+	CENTRE_FORWARD: "CENTRE_FORWARD",
+	STRIKER: "STRIKER",
+};
+
+type OnboardingData = {
+	userType: UserType;
+	birthDate?: Date;
+	city?: string;
+	position?: string;
+	foot?: string;
+	license?: string;
+	clubName?: string;
+	clubSize?: number;
+	clubPosition?: string;
+};
+
+export async function saveOnboarding(data: OnboardingData) {
+	const userId = await getUserSessionId();
+	if (!userId) {
+		return { success: false, error: "Unauthorized" };
+	}
+
+	try {
+		const updateData: Parameters<typeof prisma.user.update>[0]["data"] = {
+			userType: data.userType,
+			isOnboarded: true,
+		};
+
+		if (data.birthDate) {
+			updateData.birthday = data.birthDate;
+		}
+
+		if (data.city) {
+			updateData.localisation = data.city;
+		}
+
+		if (data.license) {
+			updateData.license = data.license;
+		}
+
+		if (data.clubName) {
+			updateData.fullName = data.clubName;
+		}
+
+		if (data.position && POSITION_MAP[data.position]) {
+			updateData.position = [POSITION_MAP[data.position] as Position];
+		}
+
+		if (data.foot) {
+			if (data.foot === "BOTH") {
+				updateData.foot = ["LEFT", "RIGHT"] as Foot[];
+			} else if (data.foot === "LEFT" || data.foot === "RIGHT") {
+				updateData.foot = [data.foot as Foot];
+			}
+		}
+
+		await prisma.user.update({
+			where: { id: userId },
+			data: updateData,
+		});
+
+		revalidatePath("/feed");
+		revalidatePath("/profile");
+
+		return { success: true };
+	} catch (error) {
+		console.error("Error saving onboarding data:", error);
+		return { success: false, error: "Failed to save onboarding data" };
+	}
+}

--- a/app/(home)/(private)/post/[id]/edit/page.tsx
+++ b/app/(home)/(private)/post/[id]/edit/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Layout } from "@/components/layouts/layout";
+import { getSession } from "@/src/lib/auth-server";
 import { getPost } from "@/src/query/post.query";
 import { PostEditForm } from "./post-edit-form";
 
@@ -14,9 +15,13 @@ export default async function page({
 	const { id } = await params;
 	const t = await getTranslations("posts.edit");
 
-	const post = await getPost(id);
+	const [session, post] = await Promise.all([getSession(), getPost(id)]);
 
 	if (!post) {
+		return notFound();
+	}
+
+	if (!session?.user?.id || post.userId !== session.user.id) {
 		return notFound();
 	}
 

--- a/app/(home)/(private)/post/[id]/edit/page.tsx
+++ b/app/(home)/(private)/post/[id]/edit/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 import { Layout } from "@/components/layouts/layout";
 import { getPost } from "@/src/query/post.query";
+import { PostEditForm } from "./post-edit-form";
 
 export default async function page({
 	params,
@@ -10,6 +12,7 @@ export default async function page({
 	}>;
 }) {
 	const { id } = await params;
+	const t = await getTranslations("posts.edit");
 
 	const post = await getPost(id);
 
@@ -19,8 +22,15 @@ export default async function page({
 
 	return (
 		<Layout>
-			<div>
-				<h1>Edit Post</h1>
+			<div className="max-w-2xl mx-auto p-4">
+				<h1 className="text-2xl font-bold mb-6">{t("title")}</h1>
+				<PostEditForm
+					post={{
+						id: post.id,
+						title: post.title,
+						description: post.description,
+					}}
+				/>
 			</div>
 		</Layout>
 	);

--- a/app/(home)/(private)/post/[id]/edit/post-edit-form.tsx
+++ b/app/(home)/(private)/post/[id]/edit/post-edit-form.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { updatePost } from "@/src/actions/post.action";
+
+const postEditSchema = z.object({
+	title: z.string().min(1),
+	description: z.string().min(1),
+});
+
+type PostEditValues = z.infer<typeof postEditSchema>;
+
+interface PostEditFormProps {
+	post: { id: string; title: string; description: string };
+}
+
+export function PostEditForm({ post }: PostEditFormProps) {
+	const t = useTranslations("posts.edit");
+	const router = useRouter();
+
+	const form = useForm<PostEditValues>({
+		resolver: zodResolver(postEditSchema),
+		defaultValues: {
+			title: post.title,
+			description: post.description,
+		},
+	});
+
+	const { isSubmitting } = form.formState;
+
+	const onSubmit = async (data: PostEditValues) => {
+		const result = await updatePost(post.id, data);
+		if (result.error) {
+			toast.error(result.error);
+			return;
+		}
+		toast.success(t("saved"));
+		router.push(`/post/${post.id}`);
+	};
+
+	return (
+		<div className="space-y-4">
+			<Link
+				href={`/post/${post.id}`}
+				className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+			>
+				<ArrowLeft className="h-4 w-4" />
+				{t("back")}
+			</Link>
+
+			<Form {...form}>
+				<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+					<FormField
+						control={form.control}
+						name="title"
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>{t("title-label")}</FormLabel>
+								<FormControl>
+									<Input {...field} disabled={isSubmitting} />
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={form.control}
+						name="description"
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>{t("description-label")}</FormLabel>
+								<FormControl>
+									<Textarea {...field} rows={4} disabled={isSubmitting} />
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<Button type="submit" disabled={isSubmitting} className="w-full">
+						{isSubmitting ? (
+							<>
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+								{t("saving")}
+							</>
+						) : (
+							t("save")
+						)}
+					</Button>
+				</form>
+			</Form>
+		</div>
+	);
+}

--- a/app/(home)/(private)/profile/change-password/change-password.action.ts
+++ b/app/(home)/(private)/profile/change-password/change-password.action.ts
@@ -29,10 +29,8 @@ export const changePassword = async ({
 		throw new Error("User not found");
 	}
 
-	const hashCurrentPassword = await hashPassword(validatedData.currentPassword);
-
 	const isPasswordValid = await comparePassword(
-		hashCurrentPassword,
+		validatedData.currentPassword,
 		user.password ?? "",
 	);
 

--- a/app/(home)/(private)/profile/favorites/favorites-list.tsx
+++ b/app/(home)/(private)/profile/favorites/favorites-list.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Media } from "@prisma/client";
 import { BookmarkX } from "lucide-react";
 import Image from "next/image";

--- a/app/(home)/(private)/profile/favorites/favorites-list.tsx
+++ b/app/(home)/(private)/profile/favorites/favorites-list.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { Media } from "@prisma/client";
+import { BookmarkX } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+
+type FavoritePost = {
+	id: string;
+	title: string;
+	medias: Media[];
+	user: { id: string; name: string | null; image: string | null };
+	_count: { likes: number; comments: number };
+};
+
+interface FavoritesListProps {
+	posts: FavoritePost[];
+	emptyLabel: string;
+}
+
+export function FavoritesList({ posts, emptyLabel }: FavoritesListProps) {
+	if (posts.length === 0) {
+		return (
+			<div className="flex flex-col items-center justify-center gap-3 py-20 text-muted-foreground">
+				<BookmarkX className="h-10 w-10" />
+				<p className="text-sm">{emptyLabel}</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="grid grid-cols-3 gap-1">
+			{posts.map((post) => {
+				const coverImage = post.medias.find((m) => m.type === "landingImage");
+				return (
+					<Link
+						key={post.id}
+						href={`/post/${post.id}`}
+						className="relative aspect-square overflow-hidden"
+					>
+						{coverImage?.url ? (
+							<Image
+								src={coverImage.url}
+								alt={post.title}
+								fill
+								className="object-cover hover:opacity-80 transition-opacity"
+							/>
+						) : (
+							<div className="w-full h-full bg-muted flex items-center justify-center">
+								<span className="text-xs text-muted-foreground text-center px-2 line-clamp-2">
+									{post.title}
+								</span>
+							</div>
+						)}
+					</Link>
+				);
+			})}
+		</div>
+	);
+}

--- a/app/(home)/(private)/profile/favorites/page.tsx
+++ b/app/(home)/(private)/profile/favorites/page.tsx
@@ -1,0 +1,26 @@
+import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { Layout } from "@/components/layouts/layout";
+import { getSession } from "@/src/lib/auth-server";
+import { getFavoritesByUser } from "@/src/query/favorite.query";
+import { FavoritesList } from "./favorites-list";
+
+export default async function FavoritesPage() {
+	const session = await getSession();
+
+	if (!session?.user?.id) {
+		redirect("/sign-in");
+	}
+
+	const t = await getTranslations("profile.favorites");
+	const posts = await getFavoritesByUser(session.user.id);
+
+	return (
+		<Layout>
+			<div className="py-4">
+				<h1 className="text-xl font-bold mb-6">{t("title")}</h1>
+				<FavoritesList posts={posts} emptyLabel={t("empty")} />
+			</div>
+		</Layout>
+	);
+}

--- a/app/(home)/(public)/about-us/page.tsx
+++ b/app/(home)/(public)/about-us/page.tsx
@@ -1,45 +1,36 @@
 import Image from "next/image";
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 import { Shell } from "@/components/shell";
 import { Button } from "@/components/ui/button";
 
-export default function AboutPage() {
+export default async function AboutPage() {
+	const t = await getTranslations("about-us");
+
 	return (
 		<Shell>
 			<div className="container mx-auto px-4 py-12">
 				<div className="grid gap-12 lg:grid-cols-2">
 					<div className="flex flex-col justify-center space-y-6">
-						<h1 className="text-4xl font-bold tracking-tight">
-							Discover Amateur Football Talent
-						</h1>
-						<p className="text-lg text-muted-foreground">
-							Football Talent Network is a platform dedicated to connecting
-							amateur football players, coaches, and clubs. We believe in making
-							football opportunities accessible to everyone, regardless of their
-							background.
-						</p>
+						<h1 className="text-4xl font-bold tracking-tight">{t("title")}</h1>
+						<p className="text-lg text-muted-foreground">{t("description")}</p>
 						<div className="space-y-4">
-							<h2 className="text-2xl font-semibold">Our Mission</h2>
-							<p className="text-muted-foreground">
-								To create a vibrant community where football talent can be
-								discovered, nurtured, and given opportunities to shine. We
-								connect passionate players with coaches and clubs, fostering the
-								growth of amateur football.
-							</p>
+							<h2 className="text-2xl font-semibold">{t("mission-title")}</h2>
+							<p className="text-muted-foreground">{t("mission")}</p>
 						</div>
 						<div className="flex gap-4">
 							<Button asChild>
-								<Link href="/auth/register">Join Our Community</Link>
+								<Link href="/sign-up">{t("join")}</Link>
 							</Button>
 							<Button variant="outline" asChild>
-								<Link href="/contact">Contact Us</Link>
+								<Link href="/contact">{t("contact")}</Link>
 							</Button>
 						</div>
 					</div>
 					<div className="relative aspect-square overflow-hidden rounded-xl lg:aspect-auto">
 						<Image
 							src="https://images.unsplash.com/photo-1517466787929-bc90951d0974?q=80&w=2000"
-							alt="Football players celebrating"
+							alt={t("title")}
 							fill
 							className="object-cover"
 							priority
@@ -49,54 +40,46 @@ export default function AboutPage() {
 
 				<div className="mt-24 grid gap-12 sm:grid-cols-2 lg:grid-cols-3">
 					<div className="space-y-4">
-						<h3 className="text-xl font-semibold">For Players</h3>
-						<p className="text-muted-foreground">
-							Create your profile, showcase your skills, and get discovered by
-							clubs and coaches. Share your journey and connect with other
-							players.
-						</p>
+						<h3 className="text-xl font-semibold">{t("for-players-title")}</h3>
+						<p className="text-muted-foreground">{t("for-players")}</p>
 					</div>
 					<div className="space-y-4">
-						<h3 className="text-xl font-semibold">For Coaches</h3>
-						<p className="text-muted-foreground">
-							Find promising talent, share your expertise, and build your
-							reputation in the amateur football community.
-						</p>
+						<h3 className="text-xl font-semibold">{t("for-coaches-title")}</h3>
+						<p className="text-muted-foreground">{t("for-coaches")}</p>
 					</div>
 					<div className="space-y-4">
-						<h3 className="text-xl font-semibold">For Clubs</h3>
-						<p className="text-muted-foreground">
-							Discover talented players, connect with qualified coaches, and
-							grow your club&apos;s presence in the amateur football scene.
-						</p>
+						<h3 className="text-xl font-semibold">{t("for-clubs-title")}</h3>
+						<p className="text-muted-foreground">{t("for-clubs")}</p>
 					</div>
 				</div>
 
 				<div className="mt-24">
-					<h2 className="mb-8 text-center text-3xl font-bold">Our Values</h2>
+					<h2 className="mb-8 text-center text-3xl font-bold">
+						{t("values-title")}
+					</h2>
 					<div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
 						<div className="rounded-lg bg-muted p-6">
-							<h3 className="mb-2 font-semibold">Community</h3>
+							<h3 className="mb-2 font-semibold">{t("value-community")}</h3>
 							<p className="text-sm text-muted-foreground">
-								Building strong connections within the football community
+								{t("value-community-desc")}
 							</p>
 						</div>
 						<div className="rounded-lg bg-muted p-6">
-							<h3 className="mb-2 font-semibold">Opportunity</h3>
+							<h3 className="mb-2 font-semibold">{t("value-opportunity")}</h3>
 							<p className="text-sm text-muted-foreground">
-								Creating chances for talent to shine and grow
+								{t("value-opportunity-desc")}
 							</p>
 						</div>
 						<div className="rounded-lg bg-muted p-6">
-							<h3 className="mb-2 font-semibold">Development</h3>
+							<h3 className="mb-2 font-semibold">{t("value-development")}</h3>
 							<p className="text-sm text-muted-foreground">
-								Supporting the growth of players, coaches, and clubs
+								{t("value-development-desc")}
 							</p>
 						</div>
 						<div className="rounded-lg bg-muted p-6">
-							<h3 className="mb-2 font-semibold">Inclusivity</h3>
+							<h3 className="mb-2 font-semibold">{t("value-inclusivity")}</h3>
 							<p className="text-sm text-muted-foreground">
-								Welcoming all who share our passion for football
+								{t("value-inclusivity-desc")}
 							</p>
 						</div>
 					</div>

--- a/app/(home)/(public)/explore/explore-header.tsx
+++ b/app/(home)/(public)/explore/explore-header.tsx
@@ -3,7 +3,7 @@
 import { Search } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useTransition } from "react";
+import { useRef, useTransition } from "react";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -12,17 +12,25 @@ export const ExploreHeader = () => {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const [, startTransition] = useTransition();
+	const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+		undefined,
+	);
 
 	const q = searchParams.get("q") ?? "";
 	const tab = searchParams.get("tab") ?? "top";
 
-	const updateParams = (newQ: string, newTab: string) => {
+	const navigateTo = (newQ: string, newTab: string) => {
 		const params = new URLSearchParams();
 		if (newQ) params.set("q", newQ);
 		params.set("tab", newTab);
 		startTransition(() => {
 			router.replace(`/explore?${params.toString()}`);
 		});
+	};
+
+	const handleSearchChange = (value: string) => {
+		clearTimeout(debounceRef.current);
+		debounceRef.current = setTimeout(() => navigateTo(value, tab), 400);
 	};
 
 	return (
@@ -36,13 +44,13 @@ export const ExploreHeader = () => {
 						placeholder={t("placeholder")}
 						className="pl-9 bg-muted border-none"
 						defaultValue={q}
-						onChange={(e) => updateParams(e.target.value, tab)}
+						onChange={(e) => handleSearchChange(e.target.value)}
 					/>
 				</div>
 			</div>
 			<Tabs
 				value={tab}
-				onValueChange={(value) => updateParams(q, value)}
+				onValueChange={(value) => navigateTo(q, value)}
 				className="w-full"
 			>
 				<TabsList className="w-full justify-between h-auto bg-transparent p-0 px-4">

--- a/app/(home)/(public)/explore/explore-header.tsx
+++ b/app/(home)/(public)/explore/explore-header.tsx
@@ -1,52 +1,80 @@
+"use client";
+
 import { Search } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useTransition } from "react";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 export const ExploreHeader = () => {
+	const t = useTranslations("explore");
+	const router = useRouter();
+	const searchParams = useSearchParams();
+	const [, startTransition] = useTransition();
+
+	const q = searchParams.get("q") ?? "";
+	const tab = searchParams.get("tab") ?? "top";
+
+	const updateParams = (newQ: string, newTab: string) => {
+		const params = new URLSearchParams();
+		if (newQ) params.set("q", newQ);
+		params.set("tab", newTab);
+		startTransition(() => {
+			router.replace(`/explore?${params.toString()}`);
+		});
+	};
+
 	return (
 		<header className="sticky top-0 z-40 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
 			<div className="px-4 py-4">
-				<h1 className="text-2xl font-semibold mb-4">Explore</h1>
+				<h1 className="text-2xl font-semibold mb-4">{t("title")}</h1>
 				<div className="relative mb-4">
 					<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 					<Input
 						type="search"
-						placeholder="Search here"
+						placeholder={t("placeholder")}
 						className="pl-9 bg-muted border-none"
+						defaultValue={q}
+						onChange={(e) => updateParams(e.target.value, tab)}
 					/>
 				</div>
 			</div>
-			<Tabs defaultValue="top" className="w-full">
+			<Tabs
+				value={tab}
+				onValueChange={(value) => updateParams(q, value)}
+				className="w-full"
+			>
 				<TabsList className="w-full justify-between h-auto bg-transparent p-0 px-4">
 					<TabsTrigger
 						value="top"
 						className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
 					>
-						Top
+						{t("tabs.top")}
 					</TabsTrigger>
 					<TabsTrigger
 						value="users"
 						className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
 					>
-						Users
+						{t("tabs.users")}
 					</TabsTrigger>
 					<TabsTrigger
 						value="hashtags"
 						className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
 					>
-						Hashtags
+						{t("tabs.hashtags")}
 					</TabsTrigger>
 					<TabsTrigger
 						value="posts"
 						className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
 					>
-						Posts
+						{t("tabs.posts")}
 					</TabsTrigger>
 					<TabsTrigger
 						value="events"
 						className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
 					>
-						Events
+						{t("tabs.events")}
 					</TabsTrigger>
 				</TabsList>
 			</Tabs>

--- a/app/(home)/(public)/explore/explore-post-results.tsx
+++ b/app/(home)/(public)/explore/explore-post-results.tsx
@@ -1,0 +1,43 @@
+import type { Media } from "@prisma/client";
+import Image from "next/image";
+import Link from "next/link";
+
+type SearchPost = {
+	id: string;
+	title: string;
+	medias: Media[];
+	user: { id: string; name: string | null; image: string | null };
+	_count: { likes: number; comments: number };
+};
+
+export function ExplorePostResults({ posts }: { posts: SearchPost[] }) {
+	return (
+		<div className="grid grid-cols-3 gap-1">
+			{posts.map((post) => {
+				const cover = post.medias.find((m) => m.type === "landingImage");
+				return (
+					<Link
+						key={post.id}
+						href={`/post/${post.id}`}
+						className="relative aspect-square overflow-hidden"
+					>
+						{cover?.url ? (
+							<Image
+								src={cover.url}
+								alt={post.title}
+								fill
+								className="object-cover hover:opacity-80 transition-opacity"
+							/>
+						) : (
+							<div className="w-full h-full bg-muted flex items-center justify-center p-2">
+								<span className="text-xs text-muted-foreground text-center line-clamp-3">
+									{post.title}
+								</span>
+							</div>
+						)}
+					</Link>
+				);
+			})}
+		</div>
+	);
+}

--- a/app/(home)/(public)/explore/page.tsx
+++ b/app/(home)/(public)/explore/page.tsx
@@ -1,5 +1,69 @@
+import { getTranslations } from "next-intl/server";
+import { UserResultItem } from "@/components/feature/search/user-result-item";
+import { searchPosts } from "@/src/query/post.query";
+import { searchUsers } from "@/src/query/user.query";
 import { ExploreHeader } from "./explore-header";
+import { ExplorePostResults } from "./explore-post-results";
 
-export default function Explore() {
-	return <ExploreHeader />;
+export default async function Explore({
+	searchParams,
+}: {
+	searchParams: Promise<{ q?: string; tab?: string }>;
+}) {
+	const { q = "", tab = "top" } = await searchParams;
+	const t = await getTranslations("explore");
+
+	const [users, posts] = await Promise.all([
+		q && (tab === "top" || tab === "users")
+			? searchUsers(q)
+			: Promise.resolve([]),
+		q && (tab === "top" || tab === "posts")
+			? searchPosts(q)
+			: Promise.resolve([]),
+	]);
+
+	return (
+		<div>
+			<ExploreHeader />
+			<div className="px-4 pb-4">
+				{!q && (
+					<p className="text-sm text-muted-foreground text-center py-12">
+						{t("empty-state")}
+					</p>
+				)}
+
+				{q && users.length === 0 && posts.length === 0 && (
+					<p className="text-sm text-muted-foreground text-center py-12">
+						{t("no-results", { query: q })}
+					</p>
+				)}
+
+				{q && (tab === "top" || tab === "users") && users.length > 0 && (
+					<div className="mb-6">
+						{tab === "top" && (
+							<h2 className="text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wide">
+								{t("tabs.users")}
+							</h2>
+						)}
+						<div className="divide-y divide-border">
+							{users.map((user) => (
+								<UserResultItem key={user.id} user={user} />
+							))}
+						</div>
+					</div>
+				)}
+
+				{q && (tab === "top" || tab === "posts") && posts.length > 0 && (
+					<div>
+						{tab === "top" && (
+							<h2 className="text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wide">
+								{t("tabs.posts")}
+							</h2>
+						)}
+						<ExplorePostResults posts={posts} />
+					</div>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/app/(home)/(public)/post/[id]/post-card.tsx
+++ b/app/(home)/(public)/post/[id]/post-card.tsx
@@ -4,10 +4,12 @@ import { useState } from "react";
 import { PostCommentsList } from "@/components/feature/post/post-comments-list";
 import { PostDetails } from "@/components/feature/post/post-details";
 import { PostFormComment } from "@/components/feature/post/post-form-comment";
+import { useSession } from "@/src/lib/auth-client";
 import type { PostWithUserAndMedias } from "@/src/types/post.types";
 
 export const PostCard = ({ post }: { post: PostWithUserAndMedias }) => {
 	const [refreshComments, setRefreshComments] = useState(0);
+	const { data: session } = useSession();
 
 	const handleCommentPosted = () => {
 		setRefreshComments((prev) => prev + 1);
@@ -20,7 +22,11 @@ export const PostCard = ({ post }: { post: PostWithUserAndMedias }) => {
 					postId={post.id}
 					onCommentPosted={handleCommentPosted}
 				/>
-				<PostCommentsList postId={post.id} key={refreshComments} />
+				<PostCommentsList
+					postId={post.id}
+					currentUserId={session?.user?.id}
+					key={refreshComments}
+				/>
 			</PostDetails>
 		</article>
 	);

--- a/app/(home)/(public)/privacy/page.tsx
+++ b/app/(home)/(public)/privacy/page.tsx
@@ -1,84 +1,44 @@
-export default function PrivacyPage() {
+import { getTranslations } from "next-intl/server";
+
+export default async function PrivacyPage() {
+	const t = await getTranslations("privacy");
+
 	return (
 		<>
-			<h1 className="text-2xl font-bold text-indigo-800">Privacy Policy</h1>
+			<h1 className="text-2xl font-bold text-indigo-800">{t("title")}</h1>
 			<p className="mt-1 text-sm text-indigo-200">
-				Last updated: {new Date("2024-09-29").toLocaleDateString()}
+				{t("last-updated")}: {new Date("2024-09-29").toLocaleDateString()}
 			</p>
 			<div className="px-4 py-5 sm:p-6">
 				<div className="prose prose-indigo max-w-none">
-					<p className="mt-2">
-						Your privacy is important to us. It is our policy to respect your
-						privacy regarding any information we may collect from you across our
-						website,{" "}
-						<a href="https://www.nfe-foot.com">https://www.nfe-foot.com</a>, and
-						other sites we own and operate.
-					</p>
+					<p className="mt-2">{t("intro")}</p>
 
-					<h2 className="mt-4 text-3xl">1. Information we collect</h2>
-					<p className="mt-2">
-						We only ask for personal information when we truly need it to
-						provide a service to you. We collect it by fair and lawful means,
-						with your knowledge and consent. We also let you know why we&apos;re
-						collecting it and how it will be used. We only retain collected
-						information for as long as 6 months.
-					</p>
+					<h2 className="mt-4 text-3xl">{t("section-1-title")}</h2>
+					<p className="mt-2">{t("section-1")}</p>
 
-					<h2 className="mt-4 text-3xl">2. Information we share</h2>
-					<p className="mt-2">
-						We don&apos;t share your personal information with third-parties,
-						except where required by law. We will only retain personal
-						information for as long as necessary to provide you with a service.
-					</p>
+					<h2 className="mt-4 text-3xl">{t("section-2-title")}</h2>
+					<p className="mt-2">{t("section-2")}</p>
 
-					<h2 className="mt-4 text-3xl">3. Log data</h2>
-					<p className="mt-2">
-						We collect information that your browser sends whenever you visit
-						our website. This log data may include information such as your
-						computer&apos;s Internet Protocol (&lsquo;IP&lsquo;) address,
-						browser type, browser version, the pages of our site that you visit,
-						the time and date of your visit, the time spent on those pages, and
-						other statistics.
-					</p>
+					<h2 className="mt-4 text-3xl">{t("section-3-title")}</h2>
+					<p className="mt-2">{t("section-3")}</p>
 
-					<h2 className="mt-4 text-3xl">4. Cookies</h2>
-					<p className="mt-2">
-						We use &quot;cookies&quot; to collect information and improve our
-						services. You have the option to either accept or refuse these
-						cookies and know when a cookie is being sent to your computer. If
-						you choose to refuse our cookies, you may not be able to use some
-						portions of our service.
-					</p>
+					<h2 className="mt-4 text-3xl">{t("section-4-title")}</h2>
+					<p className="mt-2">{t("section-4")}</p>
 
-					<h2 className="mt-4 text-3xl">5. Service providers</h2>
-					<p className="mt-2">
-						We employ third-party companies and individuals due to the following
-						reasons:
-					</p>
+					<h2 className="mt-4 text-3xl">{t("section-5-title")}</h2>
+					<p className="mt-2">{t("section-5-intro")}</p>
 					<ul className="mt-2 list-inside list-disc">
-						<li>To facilitate our service</li>
-						<li>To provide the service on our behalf</li>
-						<li>To perform service-related services</li>
-						<li>To assist us in analyzing how our service is used</li>
+						<li>{t("section-5-item-1")}</li>
+						<li>{t("section-5-item-2")}</li>
+						<li>{t("section-5-item-3")}</li>
+						<li>{t("section-5-item-4")}</li>
 					</ul>
-					<p className="mt-2">
-						We want to inform our service users that these third parties have
-						access to your personal information. The reason is to perform the
-						tasks assigned to them on our behalf. However, they are obligated
-						not to disclose or use the information for any other purpose.
-					</p>
+					<p className="mt-2">{t("section-5-outro")}</p>
 
-					<h2 className="mt-4 text-3xl">6. Security</h2>
-					<p className="mt-2">
-						security of your personal information is important to us, but
-						remember no method of transmission over the internet, or method of
-						electronic storage is 100% secure. While we strive to use
-						commercially acceptable means to protect your personal information,
-						we cannot guarantee its absolute security.
-					</p>
+					<h2 className="mt-4 text-3xl">{t("section-6-title")}</h2>
+					<p className="mt-2">{t("section-6")}</p>
 
-					<h2 className="mt-4 text-3xl">7. Links to other sites</h2>
-					<p className="mt-2" />
+					<h2 className="mt-4 text-3xl">{t("section-7-title")}</h2>
 				</div>
 			</div>
 		</>

--- a/app/(home)/(public)/terms/page.tsx
+++ b/app/(home)/(public)/terms/page.tsx
@@ -1,104 +1,66 @@
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 
-export default function TermsAndConditions() {
+export default async function TermsAndConditions() {
+	const t = await getTranslations("terms");
+
 	return (
 		<>
-			<h1 className="text-2xl font-bold text-indigo-800">
-				Terms and Conditions
-			</h1>
-			<p className="mt-1 text-sm text-indigo-200">
-				Last updated: September 29, 2024
-			</p>
+			<h1 className="text-2xl font-bold text-indigo-800">{t("title")}</h1>
+			<p className="mt-1 text-sm text-indigo-200">{t("last-updated")}</p>
 			<div className="px-4 py-5 sm:p-6">
 				<div className="prose prose-indigo max-w-none">
-					<h2>1. Acceptance of Terms</h2>
-					<p>
-						By accessing or using the Connected social network service, you
-						agree to be bound by these Terms and Conditions. If you do not agree
-						to all the terms and conditions, you may not access or use the
-						service.
-					</p>
+					<h2>{t("section-1-title")}</h2>
+					<p>{t("section-1")}</p>
 
-					<h2>2. Changes to Terms</h2>
-					<p>
-						We reserve the right to modify or replace these Terms at any time.
-						We will provide notice of any significant changes. Your continued
-						use of the Service after such modifications will constitute your
-						acknowledgment and acceptance of the modified Terms.
-					</p>
+					<h2>{t("section-2-title")}</h2>
+					<p>{t("section-2")}</p>
 
-					<h2>3. Privacy Policy</h2>
+					<h2>{t("section-3-title")}</h2>
 					<p>
-						Your use of the Service is also governed by our Privacy Policy,
-						which can be found{" "}
+						{t("section-3-prefix")}{" "}
 						<Link
 							href="/privacy"
 							className="text-indigo-600 hover:text-indigo-800"
 						>
-							here
+							{t("section-3-link")}
 						</Link>
 						.
 					</p>
 
-					<h2>4. User Accounts</h2>
-					<p>
-						When you create an account with us, you must provide accurate,
-						complete, and current information. Failure to do so constitutes a
-						breach of the Terms, which may result in immediate termination of
-						your account.
-					</p>
+					<h2>{t("section-4-title")}</h2>
+					<p>{t("section-4")}</p>
 
-					<h2>5. Content</h2>
-					<p>
-						You are responsible for the content you post on Connected. You
-						retain all rights to your content, but grant Connected a
-						non-exclusive license to use, modify, and display the content in
-						connection with the Service.
-					</p>
+					<h2>{t("section-5-title")}</h2>
+					<p>{t("section-5")}</p>
 
-					<h2>6. Prohibited Activities</h2>
-					<p>
-						You agree not to engage in any of the following prohibited
-						activities:
-					</p>
+					<h2>{t("section-6-title")}</h2>
+					<p>{t("section-6-intro")}</p>
 					<ul>
-						<li>Violating laws or rights of others</li>
-						<li>Posting unauthorized commercial communications</li>
-						<li>Uploading viruses or malicious code</li>
-						<li>Harassment or bullying of other users</li>
-						<li>Impersonating others</li>
+						<li>{t("section-6-item-1")}</li>
+						<li>{t("section-6-item-2")}</li>
+						<li>{t("section-6-item-3")}</li>
+						<li>{t("section-6-item-4")}</li>
+						<li>{t("section-6-item-5")}</li>
 					</ul>
 
-					<h2>7. Termination</h2>
-					<p>
-						We may terminate or suspend your account immediately, without prior
-						notice or liability, for any reason, including breach of Terms. Upon
-						termination, your right to use the Service will immediately cease.
-					</p>
+					<h2>{t("section-7-title")}</h2>
+					<p>{t("section-7")}</p>
 
-					<h2>8. Limitation of Liability</h2>
-					<p>
-						In no event shall Connected, its directors, employees, partners,
-						agents, suppliers, or affiliates, be liable for any indirect,
-						incidental, special, consequential or punitive damages, including
-						loss of profits, data, or other intangible losses.
-					</p>
+					<h2>{t("section-8-title")}</h2>
+					<p>{t("section-8")}</p>
 
-					<h2>9. Governing Law</h2>
-					<p>
-						These Terms shall be governed by and construed in accordance with
-						the laws of [Your Jurisdiction], without regard to its conflict of
-						law provisions.
-					</p>
+					<h2>{t("section-9-title")}</h2>
+					<p>{t("section-9")}</p>
 
-					<h2>10. Contact Us</h2>
+					<h2>{t("section-10-title")}</h2>
 					<p>
-						If you have any questions about these Terms, please contact us at{" "}
+						{t("section-10-prefix")}{" "}
 						<a
-							href="mailto:support@connected.com"
+							href="mailto:contact@nfe-foot.com"
 							className="text-indigo-600 hover:text-indigo-800"
 						>
-							support@connected.com
+							contact@nfe-foot.com
 						</a>
 						.
 					</p>
@@ -110,7 +72,7 @@ export default function TermsAndConditions() {
 						href="/"
 						className="font-medium text-indigo-600 hover:text-indigo-500"
 					>
-						Return to Home
+						{t("return-home")}
 					</Link>
 				</div>
 			</div>

--- a/app/(home)/header.tsx
+++ b/app/(home)/header.tsx
@@ -35,7 +35,7 @@ export const Header = ({ userId }: { userId?: string }) => {
 					</h1>
 					<div className="flex items-center gap-2 mr-4">
 						<LanguageSwitcher />
-						{userId && <NotificationBell userId={userId} />}
+						{userId && <NotificationBell />}
 						{userId && <HeaderDropdown userId={userId} />}
 					</div>
 				</div>

--- a/app/(home)/header.tsx
+++ b/app/(home)/header.tsx
@@ -5,6 +5,7 @@ import { LayoutDashboard, LogOutIcon, UserIcon, VideoIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+import { NotificationBell } from "@/components/feature/notifications/notification-bell";
 import { LanguageSwitcher } from "@/components/language-switcher";
 import { Layout } from "@/components/layouts/layout";
 import {
@@ -34,6 +35,7 @@ export const Header = ({ userId }: { userId?: string }) => {
 					</h1>
 					<div className="flex items-center gap-2 mr-4">
 						<LanguageSwitcher />
+						{userId && <NotificationBell userId={userId} />}
 						{userId && <HeaderDropdown userId={userId} />}
 					</div>
 				</div>

--- a/components/feature/follow/follow.action.ts
+++ b/components/feature/follow/follow.action.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
+import { createNotification } from "@/src/actions/notification.action";
 import { getUserSessionId } from "@/src/query/user.query";
 
 export const removeFollow = async ({
@@ -55,6 +56,16 @@ export const addFollow = async ({
 		});
 
 		revalidatePath(`/user/${userToFollowId}`);
+
+		const follower = await prisma.user.findUnique({
+			where: { id: userId },
+			select: { name: true },
+		});
+		createNotification(
+			userToFollowId,
+			`${follower?.name ?? "Someone"} started following you`,
+			`/user/${userId}`,
+		);
 
 		return { success: true, follow };
 	} catch (error) {

--- a/components/feature/follow/follow.action.ts
+++ b/components/feature/follow/follow.action.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
-import { createNotification } from "@/src/actions/notification.action";
+import { createNotification } from "@/src/lib/create-notification";
 import { getUserSessionId } from "@/src/query/user.query";
 
 export const removeFollow = async ({
@@ -47,6 +47,10 @@ export const addFollow = async ({
 		return { error: t("user-not-found") };
 	}
 
+	if (userId === userToFollowId) {
+		return { error: t("user-not-found") };
+	}
+
 	try {
 		const follow = await prisma.follow.create({
 			data: {
@@ -61,7 +65,7 @@ export const addFollow = async ({
 			where: { id: userId },
 			select: { name: true },
 		});
-		createNotification(
+		await createNotification(
 			userToFollowId,
 			`${follower?.name ?? "Someone"} started following you`,
 			`/user/${userId}`,

--- a/components/feature/notifications/notification-bell.tsx
+++ b/components/feature/notifications/notification-bell.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Bell } from "lucide-react";
+import Link from "next/link";
+import { getUnreadNotificationCount } from "@/src/query/notification.query";
+
+export function NotificationBell({ userId }: { userId: string }) {
+	const { data: count = 0 } = useQuery({
+		queryKey: ["notifications-count", userId],
+		queryFn: () => getUnreadNotificationCount(userId),
+		refetchInterval: 30000,
+	});
+
+	return (
+		<Link
+			href="/notifications"
+			className="relative inline-flex items-center justify-center w-9 h-9 rounded-full hover:bg-accent transition-colors"
+			aria-label="Notifications"
+		>
+			<Bell className="h-5 w-5" />
+			{count > 0 && (
+				<span className="absolute -top-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-destructive text-[10px] font-bold text-destructive-foreground">
+					{count >= 10 ? "9+" : count}
+				</span>
+			)}
+		</Link>
+	);
+}

--- a/components/feature/notifications/notification-bell.tsx
+++ b/components/feature/notifications/notification-bell.tsx
@@ -5,10 +5,10 @@ import { Bell } from "lucide-react";
 import Link from "next/link";
 import { getUnreadNotificationCount } from "@/src/query/notification.query";
 
-export function NotificationBell({ userId }: { userId: string }) {
+export function NotificationBell() {
 	const { data: count = 0 } = useQuery({
-		queryKey: ["notifications-count", userId],
-		queryFn: () => getUnreadNotificationCount(userId),
+		queryKey: ["notifications-count"],
+		queryFn: () => getUnreadNotificationCount(),
 		refetchInterval: 30000,
 	});
 

--- a/components/feature/post/post-comments-list.tsx
+++ b/components/feature/post/post-comments-list.tsx
@@ -1,15 +1,26 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
+import { Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { useLastComments } from "@/src/hooks/use-comment-query";
+import { Button } from "@/components/ui/button";
+import { deleteComment } from "@/src/actions/comment.action";
+import { commentKeys, useLastComments } from "@/src/hooks/use-comment-query";
 
 interface PostCommentsListProps {
 	postId: string;
+	currentUserId?: string | null;
 }
 
-export const PostCommentsList = ({ postId }: PostCommentsListProps) => {
+export const PostCommentsList = ({
+	postId,
+	currentUserId,
+}: PostCommentsListProps) => {
 	const t = useTranslations("posts.post-comments-list");
+	const queryClient = useQueryClient();
+	const [deletingId, setDeletingId] = useState<string | null>(null);
 
 	const {
 		data: commentsResult,
@@ -24,6 +35,19 @@ export const PostCommentsList = ({ postId }: PostCommentsListProps) => {
 		: commentsResult?.success
 			? null
 			: (commentsResult?.error ?? null);
+
+	const handleDelete = async (commentId: string) => {
+		setDeletingId(commentId);
+		try {
+			const result = await deleteComment(commentId);
+			if (result.success) {
+				queryClient.invalidateQueries({ queryKey: commentKeys.list(postId) });
+				queryClient.invalidateQueries({ queryKey: commentKeys.count(postId) });
+			}
+		} finally {
+			setDeletingId(null);
+		}
+	};
 
 	if (isLoading) {
 		return (
@@ -63,6 +87,18 @@ export const PostCommentsList = ({ postId }: PostCommentsListProps) => {
 							<span className="text-xs text-muted-foreground">
 								{new Date(comment.createdAt).toLocaleDateString()}
 							</span>
+							{currentUserId && comment.user.id === currentUserId && (
+								<Button
+									variant="ghost"
+									size="icon"
+									className="h-6 w-6 ml-auto text-muted-foreground hover:text-destructive"
+									aria-label={t("delete-comment")}
+									disabled={deletingId === comment.id}
+									onClick={() => handleDelete(comment.id)}
+								>
+									<Trash2 className="h-3 w-3" />
+								</Button>
+							)}
 						</div>
 						<p className="mt-1 text-sm">{comment.content}</p>
 					</div>

--- a/components/feature/post/post-form-comment.tsx
+++ b/components/feature/post/post-form-comment.tsx
@@ -39,22 +39,15 @@ export const PostFormComment = ({
 		e.preventDefault();
 		setError(null);
 
-		if (!userId) {
-			setError(t("you-must-be-logged-in-to-comment"));
-			return;
-		}
-
 		try {
 			CommentSchema.parse({
 				postId,
-				userId,
 				content: comment,
 			});
 
 			setIsSubmitting(true);
 			const result = await saveComment({
 				postId,
-				userId,
 				content: comment.trim(),
 			});
 

--- a/components/feature/search/user-result-item.tsx
+++ b/components/feature/search/user-result-item.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { UserType } from "@prisma/client";
+import Link from "next/link";
+import { FollowButton } from "@/components/feature/follow/follow-button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+interface UserResultItemProps {
+	user: {
+		id: string;
+		name: string | null;
+		image: string | null;
+		userType: UserType;
+	};
+}
+
+export function UserResultItem({ user }: UserResultItemProps) {
+	return (
+		<div className="flex items-center gap-3 py-2">
+			<Link href={`/user/${user.id}`}>
+				<Avatar className="h-10 w-10">
+					<AvatarImage src={user.image ?? undefined} />
+					<AvatarFallback>
+						{user.name?.charAt(0).toUpperCase() ?? "?"}
+					</AvatarFallback>
+				</Avatar>
+			</Link>
+			<Link href={`/user/${user.id}`} className="flex-1 min-w-0">
+				<p className="font-medium text-sm truncate">{user.name}</p>
+				<p className="text-xs text-muted-foreground">{user.userType}</p>
+			</Link>
+			<FollowButton userId={user.id} showText={false} />
+		</div>
+	);
+}

--- a/components/feature/user/follow-list-dialog.tsx
+++ b/components/feature/user/follow-list-dialog.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { FollowButton } from "@/components/feature/follow/follow-button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { getFollowers, getFollowing } from "@/src/query/follow.query";
+
+interface FollowListDialogProps {
+	userId: string;
+	type: "followers" | "following";
+	count: number;
+	label: string;
+}
+
+function FollowList({
+	userId,
+	type,
+}: {
+	userId: string;
+	type: "followers" | "following";
+}) {
+	const { data: users, isPending } = useQuery({
+		queryKey: [type, userId],
+		queryFn: () =>
+			type === "followers" ? getFollowers(userId) : getFollowing(userId),
+	});
+
+	if (isPending) {
+		return (
+			<div className="space-y-3 py-2">
+				{Array.from({ length: 3 }).map((_, i) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+					<div key={i} className="flex items-center gap-3">
+						<Skeleton className="h-10 w-10 rounded-full" />
+						<div className="flex-1 space-y-1">
+							<Skeleton className="h-4 w-32" />
+							<Skeleton className="h-3 w-20" />
+						</div>
+					</div>
+				))}
+			</div>
+		);
+	}
+
+	if (!users || users.length === 0) {
+		return <p className="text-center text-muted-foreground text-sm py-6">—</p>;
+	}
+
+	return (
+		<div className="space-y-3 py-2 max-h-80 overflow-y-auto">
+			{users.map((user) => (
+				<div key={user.id} className="flex items-center gap-3">
+					<Link href={`/user/${user.id}`}>
+						<Avatar className="h-10 w-10">
+							<AvatarImage src={user.image ?? undefined} />
+							<AvatarFallback>
+								{user.name?.charAt(0).toUpperCase() ?? "?"}
+							</AvatarFallback>
+						</Avatar>
+					</Link>
+					<Link href={`/user/${user.id}`} className="flex-1 min-w-0">
+						<p className="font-medium text-sm truncate">{user.name}</p>
+						<p className="text-xs text-muted-foreground">{user.userType}</p>
+					</Link>
+					<FollowButton userId={user.id} showText={false} />
+				</div>
+			))}
+		</div>
+	);
+}
+
+export function FollowListDialog({
+	userId,
+	type,
+	count,
+	label,
+}: FollowListDialogProps) {
+	const t = useTranslations("feature.user.stats");
+
+	return (
+		<Dialog>
+			<DialogTrigger asChild>
+				<button
+					type="button"
+					className="text-center cursor-pointer hover:opacity-70 transition-opacity"
+				>
+					<div className="font-bold">{count}</div>
+					<div className="text-sm text-muted-foreground">{label}</div>
+				</button>
+			</DialogTrigger>
+			<DialogContent className="max-w-sm">
+				<DialogHeader>
+					<DialogTitle>
+						{type === "followers" ? t("followers-list") : t("following-list")}
+					</DialogTitle>
+				</DialogHeader>
+				<FollowList userId={userId} type={type} />
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/components/feature/user/stats-user.tsx
+++ b/components/feature/user/stats-user.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { getCountFollowers, getCountFollowing } from "@/src/query/follow.query";
 import { getCountPosts } from "@/src/query/post.query";
+import { FollowListDialog } from "./follow-list-dialog";
 
 interface StatsInterface {
 	countPosts: number;
@@ -39,14 +40,18 @@ export const StatsUser = ({ userId }: { userId: string }) => {
 				<div className="font-bold">{stats.countPosts}</div>
 				<div className="text-sm text-muted-foreground">{t("posts")}</div>
 			</div>
-			<div>
-				<div className="font-bold">{stats.countFollowers}</div>
-				<div className="text-sm text-muted-foreground">{t("followers")}</div>
-			</div>
-			<div>
-				<div className="font-bold">{stats.countFollowing}</div>
-				<div className="text-sm text-muted-foreground">{t("following")}</div>
-			</div>
+			<FollowListDialog
+				userId={userId}
+				type="followers"
+				count={stats.countFollowers}
+				label={t("followers")}
+			/>
+			<FollowListDialog
+				userId={userId}
+				type="following"
+				count={stats.countFollowing}
+				label={t("following")}
+			/>
 		</div>
 	);
 };

--- a/components/feature/user/user-profile.tsx
+++ b/components/feature/user/user-profile.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { User } from "@prisma/client";
-import { Loader, Settings } from "lucide-react";
+import { Bookmark, Loader, Settings } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -69,6 +69,11 @@ export const UserProfile = ({
 							<Link href="/profile/edit-user">
 								<Button variant="outline" className="flex-1 max-w-[200px]">
 									{t("edit-profile")}
+								</Button>
+							</Link>
+							<Link href="/profile/favorites">
+								<Button variant="outline" size="icon" title={t("saved-posts")}>
+									<Bookmark className="h-4 w-4" />
 								</Button>
 							</Link>
 							<DropdownMenu>

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,21 @@
 {
+	"notifications": {
+		"title": "Notifications",
+		"empty": "No notifications yet"
+	},
+	"explore": {
+		"title": "Explore",
+		"placeholder": "Search players, clubs...",
+		"no-results": "No results for \"{query}\"",
+		"empty-state": "Search for players, coaches, clubs...",
+		"tabs": {
+			"top": "Top",
+			"users": "Users",
+			"posts": "Posts",
+			"hashtags": "Hashtags",
+			"events": "Events"
+		}
+	},
 	"posts": {
 		"no-posts-available": "No posts available",
 		"no-more-posts": "You're all caught up",
@@ -46,13 +63,23 @@
 			"error-loading-comments": "An error occurred while loading comments",
 			"loading-comments": "Loading comments...",
 			"no-comments": "No comments",
-			"user": "User"
+			"user": "User",
+			"delete-comment": "Delete comment"
 		},
 		"post-form-comment": {
 			"you-must-be-logged-in-to-comment": "You must be logged in to comment",
 			"an-error-occurred-while-saving-the-comment": "An error occurred while saving the comment",
 			"your-avatar": "Your Avatar",
 			"share-your-opinion": "Share your opinion..."
+		},
+		"edit": {
+			"title": "Edit Post",
+			"title-label": "Title",
+			"description-label": "Description",
+			"save": "Save changes",
+			"saving": "Saving...",
+			"back": "Back to post",
+			"saved": "Post updated successfully"
 		},
 		"post-header": {
 			"suggestion": "Suggestion",
@@ -126,6 +153,83 @@
 		"privacy": "Privacy",
 		"terms": "Terms",
 		"about-us": "About Us"
+	},
+	"terms": {
+		"title": "Terms and Conditions",
+		"last-updated": "Last updated: September 29, 2024",
+		"section-1-title": "1. Acceptance of Terms",
+		"section-1": "By accessing or using NFE, you agree to be bound by these Terms and Conditions. If you do not agree to all the terms and conditions, you may not access or use the service.",
+		"section-2-title": "2. Changes to Terms",
+		"section-2": "We reserve the right to modify or replace these Terms at any time. We will provide notice of any significant changes. Your continued use of the Service after such modifications will constitute your acknowledgment and acceptance of the modified Terms.",
+		"section-3-title": "3. Privacy Policy",
+		"section-3-prefix": "Your use of the Service is also governed by our Privacy Policy, which can be found",
+		"section-3-link": "here",
+		"section-4-title": "4. User Accounts",
+		"section-4": "When you create an account with us, you must provide accurate, complete, and current information. Failure to do so constitutes a breach of the Terms, which may result in immediate termination of your account.",
+		"section-5-title": "5. Content",
+		"section-5": "You are responsible for the content you post on NFE. You retain all rights to your content, but grant NFE a non-exclusive license to use, modify, and display the content in connection with the Service.",
+		"section-6-title": "6. Prohibited Activities",
+		"section-6-intro": "You agree not to engage in any of the following prohibited activities:",
+		"section-6-item-1": "Violating laws or rights of others",
+		"section-6-item-2": "Posting unauthorized commercial communications",
+		"section-6-item-3": "Uploading viruses or malicious code",
+		"section-6-item-4": "Harassment or bullying of other users",
+		"section-6-item-5": "Impersonating others",
+		"section-7-title": "7. Termination",
+		"section-7": "We may terminate or suspend your account immediately, without prior notice or liability, for any reason, including breach of Terms. Upon termination, your right to use the Service will immediately cease.",
+		"section-8-title": "8. Limitation of Liability",
+		"section-8": "In no event shall NFE, its directors, employees, partners, agents, suppliers, or affiliates, be liable for any indirect, incidental, special, consequential or punitive damages, including loss of profits, data, or other intangible losses.",
+		"section-9-title": "9. Governing Law",
+		"section-9": "These Terms shall be governed by and construed in accordance with applicable laws, without regard to conflict of law provisions.",
+		"section-10-title": "10. Contact Us",
+		"section-10-prefix": "If you have any questions about these Terms, please contact us at",
+		"return-home": "Return to Home"
+	},
+	"about-us": {
+		"title": "Discover Amateur Football Talent",
+		"description": "Football Talent Network is a platform dedicated to connecting amateur football players, coaches, and clubs. We believe in making football opportunities accessible to everyone, regardless of their background.",
+		"mission-title": "Our Mission",
+		"mission": "To create a vibrant community where football talent can be discovered, nurtured, and given opportunities to shine. We connect passionate players with coaches and clubs, fostering the growth of amateur football.",
+		"join": "Join Our Community",
+		"contact": "Contact Us",
+		"for-players-title": "For Players",
+		"for-players": "Create your profile, showcase your skills, and get discovered by clubs and coaches. Share your journey and connect with other players.",
+		"for-coaches-title": "For Coaches",
+		"for-coaches": "Find promising talent, share your expertise, and build your reputation in the amateur football community.",
+		"for-clubs-title": "For Clubs",
+		"for-clubs": "Discover talented players, connect with qualified coaches, and grow your club's presence in the amateur football scene.",
+		"values-title": "Our Values",
+		"value-community": "Community",
+		"value-community-desc": "Building strong connections within the football community",
+		"value-opportunity": "Opportunity",
+		"value-opportunity-desc": "Creating chances for talent to shine and grow",
+		"value-development": "Development",
+		"value-development-desc": "Supporting the growth of players, coaches, and clubs",
+		"value-inclusivity": "Inclusivity",
+		"value-inclusivity-desc": "Welcoming all who share our passion for football"
+	},
+	"privacy": {
+		"title": "Privacy Policy",
+		"last-updated": "Last updated",
+		"intro": "Your privacy is important to us. It is our policy to respect your privacy regarding any information we may collect from you across our website, https://www.nfe-foot.com, and other sites we own and operate.",
+		"section-1-title": "1. Information we collect",
+		"section-1": "We only ask for personal information when we truly need it to provide a service to you. We collect it by fair and lawful means, with your knowledge and consent. We also let you know why we're collecting it and how it will be used. We only retain collected information for as long as 6 months.",
+		"section-2-title": "2. Information we share",
+		"section-2": "We don't share your personal information with third-parties, except where required by law. We will only retain personal information for as long as necessary to provide you with a service.",
+		"section-3-title": "3. Log data",
+		"section-3": "We collect information that your browser sends whenever you visit our website. This log data may include information such as your computer's Internet Protocol ('IP') address, browser type, browser version, the pages of our site that you visit, the time and date of your visit, the time spent on those pages, and other statistics.",
+		"section-4-title": "4. Cookies",
+		"section-4": "We use \"cookies\" to collect information and improve our services. You have the option to either accept or refuse these cookies and know when a cookie is being sent to your computer. If you choose to refuse our cookies, you may not be able to use some portions of our service.",
+		"section-5-title": "5. Service providers",
+		"section-5-intro": "We employ third-party companies and individuals due to the following reasons:",
+		"section-5-item-1": "To facilitate our service",
+		"section-5-item-2": "To provide the service on our behalf",
+		"section-5-item-3": "To perform service-related services",
+		"section-5-item-4": "To assist us in analyzing how our service is used",
+		"section-5-outro": "We want to inform our service users that these third parties have access to your personal information. The reason is to perform the tasks assigned to them on our behalf. However, they are obligated not to disclose or use the information for any other purpose.",
+		"section-6-title": "6. Security",
+		"section-6": "The security of your personal information is important to us, but remember no method of transmission over the internet, or method of electronic storage is 100% secure. While we strive to use commercially acceptable means to protect your personal information, we cannot guarantee its absolute security.",
+		"section-7-title": "7. Links to other sites"
 	},
 	"not-found": {
 		"not-found": "Page not found",
@@ -263,6 +367,10 @@
 			"back-to-profile": "Back to profile",
 			"no-password-google-account": "Your account is connected via Google. You cannot change your password."
 		},
+		"favorites": {
+			"title": "Saved posts",
+			"empty": "No saved posts yet"
+		},
 		"edit-user": {
 			"edit-profile": "Edit Profile",
 			"enter-email-to-edit-profile": "Enter your email below to edit your profile",
@@ -294,12 +402,15 @@
 			"stats": {
 				"posts": "posts",
 				"followers": "followers",
-				"following": "following"
+				"following": "following",
+				"followers-list": "Followers",
+				"following-list": "Following"
 			},
 			"profile": {
 				"loading": "Loading...",
 				"cover-image": "Cover image",
 				"edit-profile": "Edit profile",
+				"saved-posts": "Saved posts",
 				"confirm-delete-account": "Are you sure you want to delete your account? This action cannot be undone.",
 				"account-deleted-successfully": "Account deleted successfully",
 				"failed-to-delete-account": "Failed to delete account",
@@ -315,7 +426,9 @@
 	},
 	"actions": {
 		"comment": {
-			"error-saving-comment": "An error occurred while saving the comment"
+			"error-saving-comment": "An error occurred while saving the comment",
+			"unauthorized": "Unauthorized",
+			"delete-comment-error": "Failed to delete comment"
 		},
 		"favorite": {
 			"user-not-found": "User not found"
@@ -334,7 +447,9 @@
 			"post-reported-successfully": "Post reported successfully",
 			"failed-to-report-post": "Failed to report post",
 			"publish-post": "Publish",
-			"draft": "Draft"
+			"draft": "Draft",
+			"update-post-error": "Failed to update post",
+			"post-updated-successfully": "Post updated successfully"
 		},
 		"user": {
 			"user-not-found": "User not found"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,4 +1,21 @@
 {
+	"notifications": {
+		"title": "Notifications",
+		"empty": "Aucune notification"
+	},
+	"explore": {
+		"title": "Explorer",
+		"placeholder": "Rechercher des joueurs, clubs...",
+		"no-results": "Aucun résultat pour « {query} »",
+		"empty-state": "Recherchez des joueurs, entraîneurs, clubs...",
+		"tabs": {
+			"top": "Top",
+			"users": "Utilisateurs",
+			"posts": "Publications",
+			"hashtags": "Hashtags",
+			"events": "Événements"
+		}
+	},
 	"posts": {
 		"no-posts-available": "Aucun post disponible",
 		"no-more-posts": "Vous êtes à jour",
@@ -46,13 +63,23 @@
 			"error-loading-comments": "Une erreur s'est produite lors de la récupération des commentaires",
 			"loading-comments": "Chargement des commentaires...",
 			"no-comments": "Aucun commentaire",
-			"user": "Utilisateur"
+			"user": "Utilisateur",
+			"delete-comment": "Supprimer le commentaire"
 		},
 		"post-form-comment": {
 			"you-must-be-logged-in-to-comment": "Vous devez être connecté pour commenter",
 			"an-error-occurred-while-saving-the-comment": "Une erreur s'est produite lors de l'enregistrement du commentaire",
 			"your-avatar": "Votre Avatar",
 			"share-your-opinion": "Partagez votre opinion..."
+		},
+		"edit": {
+			"title": "Modifier la publication",
+			"title-label": "Titre",
+			"description-label": "Description",
+			"save": "Enregistrer",
+			"saving": "Enregistrement...",
+			"back": "Retour à la publication",
+			"saved": "Publication mise à jour"
 		},
 		"post-header": {
 			"suggestion": "Suggestion",
@@ -126,6 +153,83 @@
 		"privacy": "Vie privée",
 		"terms": "Conditions d'utilisation",
 		"about-us": "À propos de nous"
+	},
+	"terms": {
+		"title": "Conditions d'utilisation",
+		"last-updated": "Dernière mise à jour : 29 septembre 2024",
+		"section-1-title": "1. Acceptation des conditions",
+		"section-1": "En accédant ou en utilisant NFE, vous acceptez d'être lié par ces conditions d'utilisation. Si vous n'acceptez pas toutes les conditions, vous ne pouvez pas accéder ni utiliser le service.",
+		"section-2-title": "2. Modifications des conditions",
+		"section-2": "Nous nous réservons le droit de modifier ou remplacer ces conditions à tout moment. Nous vous informerons de tout changement significatif. L'utilisation continue du service après ces modifications constitue votre acceptation des nouvelles conditions.",
+		"section-3-title": "3. Politique de confidentialité",
+		"section-3-prefix": "L'utilisation du service est également régie par notre politique de confidentialité, disponible",
+		"section-3-link": "ici",
+		"section-4-title": "4. Comptes utilisateur",
+		"section-4": "Lors de la création d'un compte, vous devez fournir des informations exactes, complètes et à jour. Le non-respect de cette obligation constitue une violation des conditions pouvant entraîner la résiliation immédiate de votre compte.",
+		"section-5-title": "5. Contenu",
+		"section-5": "Vous êtes responsable du contenu que vous publiez sur NFE. Vous conservez tous vos droits sur votre contenu, mais accordez à NFE une licence non exclusive pour utiliser, modifier et afficher ce contenu dans le cadre du service.",
+		"section-6-title": "6. Activités interdites",
+		"section-6-intro": "Vous acceptez de ne pas vous livrer aux activités interdites suivantes :",
+		"section-6-item-1": "Violation des lois ou des droits d'autrui",
+		"section-6-item-2": "Publication de communications commerciales non autorisées",
+		"section-6-item-3": "Téléchargement de virus ou de codes malveillants",
+		"section-6-item-4": "Harcèlement ou intimidation d'autres utilisateurs",
+		"section-6-item-5": "Usurpation d'identité",
+		"section-7-title": "7. Résiliation",
+		"section-7": "Nous pouvons résilier ou suspendre votre compte immédiatement, sans préavis ni responsabilité, pour toute raison, y compris en cas de violation des conditions. À la résiliation, votre droit d'utiliser le service cessera immédiatement.",
+		"section-8-title": "8. Limitation de responsabilité",
+		"section-8": "En aucun cas NFE, ses directeurs, employés, partenaires, agents, fournisseurs ou affiliés ne pourront être tenus responsables de tout dommage indirect, accessoire, spécial, consécutif ou punitif.",
+		"section-9-title": "9. Droit applicable",
+		"section-9": "Ces conditions sont régies et interprétées conformément aux lois applicables.",
+		"section-10-title": "10. Nous contacter",
+		"section-10-prefix": "Si vous avez des questions concernant ces conditions, veuillez nous contacter à",
+		"return-home": "Retour à l'accueil"
+	},
+	"about-us": {
+		"title": "Découvrez les talents du football amateur",
+		"description": "Football Talent Network est une plateforme dédiée à la mise en relation des joueurs, entraîneurs et clubs de football amateur. Nous croyons en l'accessibilité des opportunités footballistiques pour tous, quelle que soit leur origine.",
+		"mission-title": "Notre mission",
+		"mission": "Créer une communauté dynamique où les talents du football peuvent être découverts, développés et mis en lumière. Nous mettons en relation des joueurs passionnés avec des entraîneurs et des clubs, favorisant la croissance du football amateur.",
+		"join": "Rejoindre la communauté",
+		"contact": "Nous contacter",
+		"for-players-title": "Pour les joueurs",
+		"for-players": "Créez votre profil, mettez en valeur vos compétences et faites-vous découvrir par des clubs et des entraîneurs. Partagez votre parcours et connectez-vous avec d'autres joueurs.",
+		"for-coaches-title": "Pour les entraîneurs",
+		"for-coaches": "Trouvez des talents prometteurs, partagez votre expertise et développez votre réputation dans la communauté du football amateur.",
+		"for-clubs-title": "Pour les clubs",
+		"for-clubs": "Découvrez des joueurs talentueux, connectez-vous avec des entraîneurs qualifiés et développez la présence de votre club dans le football amateur.",
+		"values-title": "Nos valeurs",
+		"value-community": "Communauté",
+		"value-community-desc": "Créer des liens forts au sein de la communauté footballistique",
+		"value-opportunity": "Opportunité",
+		"value-opportunity-desc": "Créer des chances pour que les talents brillent et se développent",
+		"value-development": "Développement",
+		"value-development-desc": "Soutenir la croissance des joueurs, entraîneurs et clubs",
+		"value-inclusivity": "Inclusivité",
+		"value-inclusivity-desc": "Accueillir tous ceux qui partagent notre passion pour le football"
+	},
+	"privacy": {
+		"title": "Politique de confidentialité",
+		"last-updated": "Dernière mise à jour",
+		"intro": "Votre vie privée est importante pour nous. Notre politique consiste à respecter votre confidentialité concernant toute information que nous pourrions collecter auprès de vous sur notre site web, https://www.nfe-foot.com, et d'autres sites que nous possédons et exploitons.",
+		"section-1-title": "1. Informations que nous collectons",
+		"section-1": "Nous ne demandons des informations personnelles que lorsque nous en avons réellement besoin pour vous fournir un service. Nous les collectons par des moyens équitables et légaux, avec votre connaissance et votre consentement. Nous vous indiquons également pourquoi nous les collectons et comment elles seront utilisées. Nous ne conservons les informations collectées que pendant 6 mois.",
+		"section-2-title": "2. Informations que nous partageons",
+		"section-2": "Nous ne partageons pas vos informations personnelles avec des tiers, sauf si la loi l'exige. Nous ne conserverons les informations personnelles que le temps nécessaire pour vous fournir un service.",
+		"section-3-title": "3. Données de journalisation",
+		"section-3": "Nous collectons les informations que votre navigateur envoie chaque fois que vous visitez notre site. Ces données peuvent inclure des informations telles que l'adresse IP de votre ordinateur, le type de navigateur, la version du navigateur, les pages visitées, la date et l'heure de votre visite, le temps passé sur ces pages et d'autres statistiques.",
+		"section-4-title": "4. Cookies",
+		"section-4": "Nous utilisons des « cookies » pour collecter des informations et améliorer nos services. Vous pouvez accepter ou refuser ces cookies et savoir quand un cookie est envoyé à votre ordinateur. Si vous refusez nos cookies, il est possible que vous ne puissiez pas utiliser certaines parties de notre service.",
+		"section-5-title": "5. Prestataires de services",
+		"section-5-intro": "Nous faisons appel à des entreprises et des personnes tierces pour les raisons suivantes :",
+		"section-5-item-1": "Pour faciliter notre service",
+		"section-5-item-2": "Pour fournir le service en notre nom",
+		"section-5-item-3": "Pour effectuer des services liés au service",
+		"section-5-item-4": "Pour nous aider à analyser la façon dont notre service est utilisé",
+		"section-5-outro": "Nous tenons à informer les utilisateurs de notre service que ces tiers ont accès à vos informations personnelles afin d'effectuer les tâches qui leur sont assignées en notre nom. Cependant, ils sont tenus de ne pas divulguer ou utiliser ces informations à d'autres fins.",
+		"section-6-title": "6. Sécurité",
+		"section-6": "La sécurité de vos informations personnelles est importante pour nous, mais aucune méthode de transmission sur Internet ou de stockage électronique n'est sécurisée à 100 %. Bien que nous nous efforcions d'utiliser des moyens commercialement acceptables pour protéger vos informations personnelles, nous ne pouvons garantir leur sécurité absolue.",
+		"section-7-title": "7. Liens vers d'autres sites"
 	},
 	"not-found": {
 		"not-found": "Page non trouvée",
@@ -263,6 +367,10 @@
 			"back-to-profile": "Retour au profil",
 			"no-password-google-account": "Votre compte est connecté via Google. Vous ne pouvez pas changer de mot de passe."
 		},
+		"favorites": {
+			"title": "Publications sauvegardées",
+			"empty": "Aucune publication sauvegardée"
+		},
 		"edit-user": {
 			"edit-profile": "Modifier le profil",
 			"enter-email-to-edit-profile": "Entrez votre email ci-dessous pour modifier votre profil",
@@ -294,12 +402,15 @@
 			"stats": {
 				"posts": "posts",
 				"followers": "abonnés",
-				"following": "abonnements"
+				"following": "abonnements",
+				"followers-list": "Abonnés",
+				"following-list": "Abonnements"
 			},
 			"profile": {
 				"loading": "Chargement...",
 				"cover-image": "Image de couverture",
 				"edit-profile": "Modifier le profil",
+				"saved-posts": "Publications sauvegardées",
 				"confirm-delete-account": "Êtes-vous sûr de vouloir supprimer votre compte ? Cette action ne peut pas être annulée.",
 				"account-deleted-successfully": "Compte supprimé avec succès",
 				"failed-to-delete-account": "Échec de la suppression du compte",
@@ -315,7 +426,9 @@
 	},
 	"actions": {
 		"comment": {
-			"error-saving-comment": "Une erreur s'est produite lors de l'enregistrement du commentaire"
+			"error-saving-comment": "Une erreur s'est produite lors de l'enregistrement du commentaire",
+			"unauthorized": "Non autorisé",
+			"delete-comment-error": "Impossible de supprimer le commentaire"
 		},
 		"favorite": {
 			"user-not-found": "Utilisateur non trouvé"
@@ -334,7 +447,9 @@
 			"post-reported-successfully": "Post signalé avec succès",
 			"failed-to-report-post": "Échec du signalement du post",
 			"publish-post": "Publier",
-			"draft": "Brouillon"
+			"draft": "Brouillon",
+			"update-post-error": "Impossible de mettre à jour la publication",
+			"post-updated-successfully": "Publication mise à jour"
 		},
 		"user": {
 			"user-not-found": "Utilisateur non trouvé"

--- a/src/actions/comment.action.ts
+++ b/src/actions/comment.action.ts
@@ -3,12 +3,12 @@
 import { getTranslations } from "next-intl/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
+import { createNotification } from "@/src/lib/create-notification";
 import { getUserSessionId } from "@/src/query/user.query";
 import {
 	type CommentFormData,
 	CommentSchema,
 } from "@/src/schemas/comment.schema";
-import { createNotification } from "./notification.action";
 
 export const saveComment = async (data: CommentFormData) => {
 	const t = await getTranslations("actions.comment");
@@ -41,7 +41,7 @@ export const saveComment = async (data: CommentFormData) => {
 				where: { id: userId },
 				select: { name: true },
 			});
-			createNotification(
+			await createNotification(
 				post.userId,
 				`${commenter?.name ?? "Someone"} commented on your post`,
 				`/post/${validatedData.postId}`,

--- a/src/actions/comment.action.ts
+++ b/src/actions/comment.action.ts
@@ -3,21 +3,50 @@
 import { getTranslations } from "next-intl/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
+import { getUserSessionId } from "@/src/query/user.query";
 import {
 	type CommentFormData,
 	CommentSchema,
 } from "@/src/schemas/comment.schema";
+import { createNotification } from "./notification.action";
 
 export const saveComment = async (data: CommentFormData) => {
 	const t = await getTranslations("actions.comment");
 
+	const userId = await getUserSessionId();
+	if (!userId) {
+		return {
+			success: false,
+			error: [{ message: t("unauthorized") }],
+		};
+	}
+
 	try {
-		// Validate the input data
 		const validatedData = CommentSchema.parse(data);
 
 		const comment = await prisma.comment.create({
-			data: validatedData,
+			data: {
+				postId: validatedData.postId,
+				content: validatedData.content,
+				userId,
+			},
 		});
+
+		const post = await prisma.post.findUnique({
+			where: { id: validatedData.postId },
+			select: { userId: true },
+		});
+		if (post && post.userId !== userId) {
+			const commenter = await prisma.user.findUnique({
+				where: { id: userId },
+				select: { name: true },
+			});
+			createNotification(
+				post.userId,
+				`${commenter?.name ?? "Someone"} commented on your post`,
+				`/post/${validatedData.postId}`,
+			);
+		}
 
 		return { success: true, data: comment };
 	} catch (error) {
@@ -34,5 +63,36 @@ export const saveComment = async (data: CommentFormData) => {
 				},
 			],
 		};
+	}
+};
+
+export const deleteComment = async (commentId: string) => {
+	const t = await getTranslations("actions.comment");
+
+	const userId = await getUserSessionId();
+	if (!userId) {
+		return { success: false, error: t("unauthorized") };
+	}
+
+	try {
+		const comment = await prisma.comment.findUnique({
+			where: { id: commentId },
+			select: { userId: true, postId: true },
+		});
+
+		if (!comment) {
+			return { success: false, error: t("delete-comment-error") };
+		}
+
+		if (comment.userId !== userId) {
+			return { success: false, error: t("unauthorized") };
+		}
+
+		await prisma.comment.delete({ where: { id: commentId } });
+
+		return { success: true };
+	} catch (error) {
+		console.error("Error deleting comment:", error);
+		return { success: false, error: t("delete-comment-error") };
 	}
 };

--- a/src/actions/like.action.ts
+++ b/src/actions/like.action.ts
@@ -3,6 +3,7 @@
 import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { getUserSession } from "@/src/query/user.query";
+import { createNotification } from "./notification.action";
 
 export const toggleLike = async ({
 	postId,
@@ -42,6 +43,23 @@ export const toggleLike = async ({
 			userId,
 		},
 	});
+
+	const post = await prisma.post.findUnique({
+		where: { id: postId },
+		select: { userId: true },
+	});
+
+	if (post && post.userId !== userId) {
+		const liker = await prisma.user.findUnique({
+			where: { id: userId },
+			select: { name: true },
+		});
+		createNotification(
+			post.userId,
+			`${liker?.name ?? "Someone"} liked your post`,
+			`/post/${postId}`,
+		);
+	}
 
 	return true;
 };

--- a/src/actions/like.action.ts
+++ b/src/actions/like.action.ts
@@ -2,8 +2,8 @@
 
 import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
+import { createNotification } from "@/src/lib/create-notification";
 import { getUserSession } from "@/src/query/user.query";
-import { createNotification } from "./notification.action";
 
 export const toggleLike = async ({
 	postId,
@@ -54,7 +54,7 @@ export const toggleLike = async ({
 			where: { id: userId },
 			select: { name: true },
 		});
-		createNotification(
+		await createNotification(
 			post.userId,
 			`${liker?.name ?? "Someone"} liked your post`,
 			`/post/${postId}`,

--- a/src/actions/notification.action.ts
+++ b/src/actions/notification.action.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { getUserSessionId } from "@/src/query/user.query";
+
+export async function createNotification(
+	userId: string,
+	content: string,
+	link?: string,
+) {
+	try {
+		await prisma.notification.create({
+			data: { userId, content, link },
+		});
+	} catch (error) {
+		console.error("Error creating notification:", error);
+	}
+}
+
+export async function markNotificationRead(notifId: string) {
+	const currentUserId = await getUserSessionId();
+	if (!currentUserId) return { success: false };
+
+	const notification = await prisma.notification.findUnique({
+		where: { id: notifId },
+		select: { userId: true },
+	});
+
+	if (!notification || notification.userId !== currentUserId) {
+		return { success: false };
+	}
+
+	await prisma.notification.update({
+		where: { id: notifId },
+		data: { readAt: new Date() },
+	});
+
+	return { success: true };
+}
+
+export async function markAllNotificationsRead() {
+	const currentUserId = await getUserSessionId();
+	if (!currentUserId) return { success: false };
+
+	await prisma.notification.updateMany({
+		where: { userId: currentUserId, readAt: null },
+		data: { readAt: new Date() },
+	});
+
+	return { success: true };
+}

--- a/src/actions/notification.action.ts
+++ b/src/actions/notification.action.ts
@@ -3,20 +3,6 @@
 import { prisma } from "@/lib/prisma";
 import { getUserSessionId } from "@/src/query/user.query";
 
-export async function createNotification(
-	userId: string,
-	content: string,
-	link?: string,
-) {
-	try {
-		await prisma.notification.create({
-			data: { userId, content, link },
-		});
-	} catch (error) {
-		console.error("Error creating notification:", error);
-	}
-}
-
 export async function markNotificationRead(notifId: string) {
 	const currentUserId = await getUserSessionId();
 	if (!currentUserId) return { success: false };

--- a/src/actions/post.action.ts
+++ b/src/actions/post.action.ts
@@ -6,6 +6,42 @@ import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { getUserSessionId } from "../query/user.query";
 
+export async function updatePost(
+	postId: string,
+	data: { title: string; description: string },
+) {
+	const t = await getTranslations("actions.post");
+
+	const userId = await getUserSessionId();
+	if (!userId) {
+		return { error: t("unauthorized") };
+	}
+
+	const post = await prisma.post.findUnique({
+		where: { id: postId },
+		select: { userId: true },
+	});
+
+	if (!post || post.userId !== userId) {
+		return { error: t("unauthorized") };
+	}
+
+	try {
+		await prisma.post.update({
+			where: { id: postId },
+			data: { title: data.title, description: data.description },
+		});
+
+		revalidatePath(`/post/${postId}`);
+		revalidatePath("/");
+
+		return { success: true };
+	} catch (error) {
+		console.error("Error updating post:", error);
+		return { error: t("update-post-error") };
+	}
+}
+
 export async function publishPost(postId: string) {
 	const t = await getTranslations("actions.post");
 

--- a/src/lib/create-notification.ts
+++ b/src/lib/create-notification.ts
@@ -1,0 +1,15 @@
+import { prisma } from "@/lib/prisma";
+
+export async function createNotification(
+	userId: string,
+	content: string,
+	link?: string,
+) {
+	try {
+		await prisma.notification.create({
+			data: { userId, content, link },
+		});
+	} catch (error) {
+		console.error("Error creating notification:", error);
+	}
+}

--- a/src/query/comment.query.ts
+++ b/src/query/comment.query.ts
@@ -11,6 +11,7 @@ export type LastCommentsResult = {
 
 export type CommentWithUser = Comment & {
 	user: {
+		id: string;
 		name: string | null;
 		image: string | null;
 	};
@@ -54,6 +55,7 @@ export const getLastComments = async (
 			include: {
 				user: {
 					select: {
+						id: true,
 						name: true,
 						image: true,
 					},

--- a/src/query/favorite.query.ts
+++ b/src/query/favorite.query.ts
@@ -3,6 +3,28 @@
 import { prisma } from "@/lib/prisma";
 import { getUserSessionId } from "./user.query";
 
+export const getFavoritesByUser = async (userId: string) => {
+	const favorites = await prisma.favorite.findMany({
+		where: { userId },
+		include: {
+			post: {
+				include: {
+					medias: true,
+					user: {
+						select: { id: true, name: true, image: true },
+					},
+					_count: {
+						select: { likes: true, comments: true },
+					},
+				},
+			},
+		},
+		orderBy: { createdAt: "desc" },
+	});
+
+	return favorites.map((f) => f.post);
+};
+
 export const hasFavorited = async ({
 	userId,
 	postId,

--- a/src/query/follow.query.ts
+++ b/src/query/follow.query.ts
@@ -25,6 +25,32 @@ export const getCountFollowing = async (userId: string): Promise<number> => {
 	return countFollowing;
 };
 
+export async function getFollowers(userId: string) {
+	const follows = await prisma.follow.findMany({
+		where: { followingId: userId },
+		include: {
+			follower: {
+				select: { id: true, name: true, image: true, userType: true },
+			},
+		},
+		orderBy: { createdAt: "desc" },
+	});
+	return follows.map((f) => f.follower);
+}
+
+export async function getFollowing(userId: string) {
+	const follows = await prisma.follow.findMany({
+		where: { followerId: userId },
+		include: {
+			followed: {
+				select: { id: true, name: true, image: true, userType: true },
+			},
+		},
+		orderBy: { createdAt: "desc" },
+	});
+	return follows.map((f) => f.followed);
+}
+
 export async function checkIsFollowing(
 	userToFollowId: string,
 ): Promise<boolean> {

--- a/src/query/notification.query.ts
+++ b/src/query/notification.query.ts
@@ -1,8 +1,12 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
+import { getUserSessionId } from "@/src/query/user.query";
 
-export const getNotifications = async (userId: string) => {
+export const getNotifications = async () => {
+	const userId = await getUserSessionId();
+	if (!userId) return [];
+
 	return prisma.notification.findMany({
 		where: { userId },
 		orderBy: { createdAt: "desc" },
@@ -10,9 +14,10 @@ export const getNotifications = async (userId: string) => {
 	});
 };
 
-export const getUnreadNotificationCount = async (
-	userId: string,
-): Promise<number> => {
+export const getUnreadNotificationCount = async (): Promise<number> => {
+	const userId = await getUserSessionId();
+	if (!userId) return 0;
+
 	return prisma.notification.count({
 		where: { userId, readAt: null },
 	});

--- a/src/query/notification.query.ts
+++ b/src/query/notification.query.ts
@@ -1,0 +1,19 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+
+export const getNotifications = async (userId: string) => {
+	return prisma.notification.findMany({
+		where: { userId },
+		orderBy: { createdAt: "desc" },
+		take: 20,
+	});
+};
+
+export const getUnreadNotificationCount = async (
+	userId: string,
+): Promise<number> => {
+	return prisma.notification.count({
+		where: { userId, readAt: null },
+	});
+};

--- a/src/query/post.query.ts
+++ b/src/query/post.query.ts
@@ -116,6 +116,27 @@ export const getPost = async (
 	return post;
 };
 
+export async function searchPosts(query: string, limit = 10) {
+	if (!query.trim()) return [];
+
+	return prisma.post.findMany({
+		where: {
+			status: "PUBLISHED",
+			OR: [
+				{ title: { contains: query, mode: "insensitive" } },
+				{ description: { contains: query, mode: "insensitive" } },
+			],
+		},
+		include: {
+			medias: true,
+			user: { select: { id: true, name: true, image: true } },
+			_count: { select: { likes: true, comments: true } },
+		},
+		take: limit,
+		orderBy: { publishedAt: "desc" },
+	});
+}
+
 export async function getPopularPostsForSitemap() {
 	try {
 		const posts = await prisma.post.findMany({

--- a/src/query/user.query.ts
+++ b/src/query/user.query.ts
@@ -109,10 +109,7 @@ export async function searchUsers(query: string, limit = 10) {
 	return prisma.user.findMany({
 		where: {
 			isOnboarded: true,
-			OR: [
-				{ name: { contains: query, mode: "insensitive" } },
-				{ email: { contains: query, mode: "insensitive" } },
-			],
+			name: { contains: query, mode: "insensitive" },
 		},
 		select: { id: true, name: true, image: true, userType: true },
 		take: limit,

--- a/src/query/user.query.ts
+++ b/src/query/user.query.ts
@@ -103,6 +103,22 @@ export const getUsers = async ({
 	return users;
 };
 
+export async function searchUsers(query: string, limit = 10) {
+	if (!query.trim()) return [];
+
+	return prisma.user.findMany({
+		where: {
+			isOnboarded: true,
+			OR: [
+				{ name: { contains: query, mode: "insensitive" } },
+				{ email: { contains: query, mode: "insensitive" } },
+			],
+		},
+		select: { id: true, name: true, image: true, userType: true },
+		take: limit,
+	});
+}
+
 export async function getUsersForSitemap() {
 	try {
 		const users = await prisma.user.findMany({

--- a/src/schemas/comment.schema.ts
+++ b/src/schemas/comment.schema.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 export const CommentSchema = z.object({
 	postId: z.string().min(1, "Post ID is required"),
-	userId: z.string().min(1, "User ID is required"),
 	content: z
 		.string()
 		.min(1, "Le commentaire ne peut pas être vide")


### PR DESCRIPTION
## Summary

- **Bug fixes**: comment userId spoofing (server-side auth guard), change-password double-hash, onboarding data loss (server action), double toast on auth redirect
- **Features**: comment delete, post edit, favorites page, followers/following list dialogs, notification system (bell + page), search/explore with users & posts
- **i18n**: translate privacy, terms, about-us pages (en + fr), add all new translation keys

## Test plan

- [ ] Post a comment — verify userId comes from server session, not client
- [ ] Change password — verify it succeeds with correct current password
- [ ] Complete onboarding — verify user data is saved in DB
- [ ] Click message icon while logged out — verify only one redirect, no double toast
- [ ] Delete own comment — verify trash icon appears, comment is removed
- [ ] Edit a post — verify title/description update
- [ ] Bookmark posts, visit `/profile/favorites` — verify grid
- [ ] Click followers/following counts — verify dialog opens with user list
- [ ] Like/comment/follow — verify notification bell badge increments
- [ ] Visit `/notifications` — verify list clears badge
- [ ] Search in `/explore` — verify user and post results
- [ ] Visit `/privacy`, `/terms`, `/about-us` — verify French translations