### PR TITLE
feat: signal moderation, profile fields & contact page

### DIFF
--- a/app/(home)/(private)/admin/page.tsx
+++ b/app/(home)/(private)/admin/page.tsx
@@ -1,9 +1,16 @@
-import { UsersIcon } from "lucide-react";
+import { FlagIcon, UsersIcon } from "lucide-react";
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 import { Layout } from "@/components/layouts/layout";
 import { Button } from "@/components/ui/button";
+import { getPendingSignalCount } from "@/src/query/signal.query";
 
-export default function AdminPage() {
+export default async function AdminPage() {
+	const [t, pendingCount] = await Promise.all([
+		getTranslations("admin"),
+		getPendingSignalCount(),
+	]);
+
 	return (
 		<Layout>
 			<div className="flex flex-col gap-4">
@@ -11,12 +18,25 @@ export default function AdminPage() {
 				<p className="text-sm text-muted-foreground">
 					Welcome to the admin dashboard
 				</p>
-				<Link href="/admin/users" className="text-sm text-muted-foreground">
-					<Button variant="outline" className="w-fit">
-						<UsersIcon className="w-4 h-4" />
-						Users
-					</Button>
-				</Link>
+				<div className="flex gap-3 flex-wrap">
+					<Link href="/admin/users" className="text-sm text-muted-foreground">
+						<Button variant="outline" className="w-fit">
+							<UsersIcon className="w-4 h-4" />
+							Users
+						</Button>
+					</Link>
+					<Link href="/admin/signals" className="relative">
+						<Button variant="outline" className="w-fit">
+							<FlagIcon className="w-4 h-4" />
+							{t("signals")}
+						</Button>
+						{pendingCount > 0 && (
+							<span className="absolute -top-1 -right-1 h-5 w-5 rounded-full bg-destructive text-destructive-foreground text-xs flex items-center justify-center font-medium">
+								{pendingCount > 9 ? "9+" : pendingCount}
+							</span>
+						)}
+					</Link>
+				</div>
 			</div>
 		</Layout>
 	);

--- a/app/(home)/(private)/admin/page.tsx
+++ b/app/(home)/(private)/admin/page.tsx
@@ -1,11 +1,17 @@
 import { FlagIcon, UsersIcon } from "lucide-react";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Layout } from "@/components/layouts/layout";
 import { Button } from "@/components/ui/button";
 import { getPendingSignalCount } from "@/src/query/signal.query";
+import { getUserRole, getUserSessionId } from "@/src/query/user.query";
 
 export default async function AdminPage() {
+	const userId = await getUserSessionId();
+	const role = userId ? await getUserRole(userId) : null;
+	if (role !== "ADMIN") redirect("/");
+
 	const [t, pendingCount] = await Promise.all([
 		getTranslations("admin"),
 		getPendingSignalCount(),

--- a/app/(home)/(private)/admin/signals/_components/signal-list.tsx
+++ b/app/(home)/(private)/admin/signals/_components/signal-list.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import type { SignalStatus } from "@prisma/client";
+import { formatDistanceToNow } from "date-fns";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { useTransition } from "react";
+import { toast } from "sonner";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+	dismissSignal,
+	rejectSignaledPost,
+	reviewSignal,
+} from "@/src/actions/signal.action";
+import type { SignalWithRelations } from "@/src/query/signal.query";
+
+const REASON_KEY_MAP: Record<string, string> = {
+	INAPPROPRIATE: "reason-inappropriate",
+	SPAM: "reason-spam",
+	OFFENSIVE: "reason-offensive",
+	MISLEADING: "reason-misleading",
+	OTHER: "reason-other",
+};
+
+export function SignalList({
+	signals,
+	status,
+}: {
+	signals: SignalWithRelations[];
+	status: SignalStatus;
+}) {
+	const t = useTranslations("admin.moderation");
+
+	if (signals.length === 0) {
+		return (
+			<p className="text-sm text-muted-foreground text-center py-12">
+				{t("no-signals")}
+			</p>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-4">
+			{signals.map((signal) => (
+				<SignalCard key={signal.id} signal={signal} status={status} />
+			))}
+		</div>
+	);
+}
+
+function SignalCard({
+	signal,
+	status,
+}: {
+	signal: SignalWithRelations;
+	status: SignalStatus;
+}) {
+	const t = useTranslations("admin.moderation");
+	const [isPending, startTransition] = useTransition();
+
+	const handleKeep = () => {
+		startTransition(async () => {
+			const result = await reviewSignal(signal.id);
+			if (result.error) {
+				toast.error(result.error);
+			} else {
+				toast.success(t("post-kept"));
+			}
+		});
+	};
+
+	const handleReject = () => {
+		startTransition(async () => {
+			const result = await rejectSignaledPost(signal.postId, signal.id);
+			if (result.error) {
+				toast.error(result.error);
+			} else {
+				toast.success(t("post-rejected"));
+			}
+		});
+	};
+
+	const handleDismiss = () => {
+		startTransition(async () => {
+			const result = await dismissSignal(signal.id);
+			if (result.error) {
+				toast.error(result.error);
+			} else {
+				toast.success(t("signal-dismissed"));
+			}
+		});
+	};
+
+	return (
+		<Card className="p-4">
+			<div className="flex flex-col gap-3">
+				<div className="flex items-start justify-between gap-4">
+					<div className="flex-1 min-w-0">
+						<Link
+							href={`/post/${signal.postId}`}
+							className="font-medium hover:underline truncate block"
+						>
+							{signal.post.title ?? t("post")}
+						</Link>
+						<div className="flex items-center gap-2 mt-1 text-sm text-muted-foreground">
+							<span>
+								{t("reason")}:{" "}
+								<span className="text-foreground">
+									{t(
+										(REASON_KEY_MAP[signal.reason] ??
+											"reason-other") as Parameters<typeof t>[0],
+									)}
+								</span>
+							</span>
+						</div>
+						{signal.details && (
+							<p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+								{signal.details}
+							</p>
+						)}
+					</div>
+
+					{status !== "PENDING" && (
+						<Badge variant={status === "REVIEWED" ? "secondary" : "outline"}>
+							{t(status.toLowerCase() as Parameters<typeof t>[0])}
+						</Badge>
+					)}
+				</div>
+
+				<div className="flex items-center gap-2 text-sm text-muted-foreground">
+					<Avatar className="h-6 w-6">
+						<AvatarImage
+							src={signal.user.image ?? ""}
+							alt={signal.user.name ?? ""}
+						/>
+						<AvatarFallback>{(signal.user.name ?? "?")[0]}</AvatarFallback>
+					</Avatar>
+					<span>{signal.user.name}</span>
+					<span>·</span>
+					<span>
+						{formatDistanceToNow(new Date(signal.createdAt), {
+							addSuffix: true,
+						})}
+					</span>
+				</div>
+
+				{status === "PENDING" && (
+					<div className="flex gap-2 pt-1">
+						<Button
+							size="sm"
+							variant="outline"
+							onClick={handleKeep}
+							disabled={isPending}
+						>
+							{t("keep-post")}
+						</Button>
+						<Button
+							size="sm"
+							variant="destructive"
+							onClick={handleReject}
+							disabled={isPending}
+						>
+							{t("reject-post")}
+						</Button>
+						<Button
+							size="sm"
+							variant="ghost"
+							onClick={handleDismiss}
+							disabled={isPending}
+						>
+							{t("dismiss")}
+						</Button>
+					</div>
+				)}
+			</div>
+		</Card>
+	);
+}

--- a/app/(home)/(private)/admin/signals/page.tsx
+++ b/app/(home)/(private)/admin/signals/page.tsx
@@ -1,0 +1,56 @@
+import type { SignalStatus } from "@prisma/client";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { Layout } from "@/components/layouts/layout";
+import { getSignals } from "@/src/query/signal.query";
+import { SignalList } from "./_components/signal-list";
+
+const TABS: { status: SignalStatus; key: string }[] = [
+	{ status: "PENDING", key: "pending" },
+	{ status: "REVIEWED", key: "reviewed" },
+	{ status: "DISMISSED", key: "dismissed" },
+];
+
+export default async function AdminSignalsPage({
+	searchParams,
+}: {
+	searchParams: Promise<{ status?: string }>;
+}) {
+	const { status = "PENDING" } = await searchParams;
+	const t = await getTranslations("admin.moderation");
+
+	const currentStatus =
+		TABS.find((tab) => tab.status === status)?.status ?? "PENDING";
+	const signals = await getSignals(currentStatus);
+
+	return (
+		<Layout>
+			<div className="flex flex-col gap-6">
+				<div>
+					<h1 className="text-2xl font-bold">{t("title")}</h1>
+					<p className="text-sm text-muted-foreground mt-1">
+						{t("description")}
+					</p>
+				</div>
+
+				<div className="flex gap-1 border-b">
+					{TABS.map((tab) => (
+						<Link
+							key={tab.status}
+							href={`/admin/signals?status=${tab.status}`}
+							className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+								currentStatus === tab.status
+									? "border-primary text-foreground"
+									: "border-transparent text-muted-foreground hover:text-foreground"
+							}`}
+						>
+							{t(tab.key as Parameters<typeof t>[0])}
+						</Link>
+					))}
+				</div>
+
+				<SignalList signals={signals} status={currentStatus} />
+			</div>
+		</Layout>
+	);
+}

--- a/app/(home)/(private)/admin/signals/page.tsx
+++ b/app/(home)/(private)/admin/signals/page.tsx
@@ -1,8 +1,10 @@
 import type { SignalStatus } from "@prisma/client";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Layout } from "@/components/layouts/layout";
 import { getSignals } from "@/src/query/signal.query";
+import { getUserRole, getUserSessionId } from "@/src/query/user.query";
 import { SignalList } from "./_components/signal-list";
 
 const TABS: { status: SignalStatus; key: string }[] = [
@@ -16,6 +18,10 @@ export default async function AdminSignalsPage({
 }: {
 	searchParams: Promise<{ status?: string }>;
 }) {
+	const userId = await getUserSessionId();
+	const role = userId ? await getUserRole(userId) : null;
+	if (role !== "ADMIN") redirect("/");
+
 	const { status = "PENDING" } = await searchParams;
 	const t = await getTranslations("admin.moderation");
 

--- a/app/(home)/(private)/messages/[user_id]/page.tsx
+++ b/app/(home)/(private)/messages/[user_id]/page.tsx
@@ -14,7 +14,7 @@ export default async function page({
 	const [session, { user_id }] = await Promise.all([getSession(), params]);
 
 	if (!session) {
-		redirect("/login");
+		redirect("/sign-in");
 	}
 
 	const messages = await prisma.message.findMany({
@@ -46,23 +46,19 @@ export default async function page({
 	});
 
 	return (
-		<div className="flex flex-col h-full">
-			<div className="flex-1 overflow-y-auto p-4 space-y-4">
+		<>
+			<div className="p-4 space-y-4 pb-32">
 				{messages.map((message) => {
 					const isOwnMessage = message.fromUserId === session.user.id;
 					return (
 						<div
 							key={message.id}
-							className={`flex ${
-								isOwnMessage ? "justify-end" : "justify-start"
-							}`}
+							className={`flex ${isOwnMessage ? "justify-end" : "justify-start"}`}
 						>
 							<div
-								className={`flex items-start gap-2 max-w-[70%] ${
-									isOwnMessage ? "flex-row-reverse" : "flex-row"
-								}`}
+								className={`flex items-end gap-2 max-w-[75%] ${isOwnMessage ? "flex-row-reverse" : "flex-row"}`}
 							>
-								<div className="relative w-8 h-8 rounded-full overflow-hidden">
+								<div className="relative w-8 h-8 rounded-full overflow-hidden shrink-0">
 									<Image
 										src={message.fromUser.image || "/default-avatar.png"}
 										alt={message.fromUser.name || "Utilisateur"}
@@ -71,14 +67,14 @@ export default async function page({
 									/>
 								</div>
 								<div
-									className={`rounded-lg p-3 ${
+									className={`rounded-2xl px-4 py-2.5 ${
 										isOwnMessage
-											? "bg-blue-500 text-white"
-											: "bg-gray-100 text-gray-900"
+											? "bg-primary text-primary-foreground rounded-br-sm"
+											: "bg-muted text-foreground rounded-bl-sm"
 									}`}
 								>
 									<p className="text-sm">{message.content}</p>
-									<p className="text-xs mt-1 opacity-70">
+									<p className="text-[10px] mt-1 opacity-60">
 										{format(new Date(message.createdAt), "HH:mm", {
 											locale: fr,
 										})}
@@ -89,9 +85,12 @@ export default async function page({
 					);
 				})}
 			</div>
-			<div className="border-t p-4">
-				<MessageForm toUserId={user_id} />
+
+			<div className="fixed bottom-20 inset-x-0 bg-background/95 backdrop-blur border-t border-border p-3">
+				<div className="max-w-2xl mx-auto">
+					<MessageForm toUserId={user_id} />
+				</div>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/app/(home)/(private)/post/my/page.tsx
+++ b/app/(home)/(private)/post/my/page.tsx
@@ -1,10 +1,24 @@
+import type { PostStatus } from "@prisma/client";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { PostDetails } from "@/components/feature/post/post-details";
+import { Badge } from "@/components/ui/badge";
 import { getPosts } from "@/src/query/post.query";
 import { getUserSession } from "@/src/query/user.query";
 
 export const dynamic = "force-dynamic";
+
+type StatusVariant = "secondary" | "outline" | "destructive";
+
+const STATUS_CONFIG: Record<
+	Exclude<PostStatus, "PUBLISHED">,
+	{ variant: StatusVariant; key: string }
+> = {
+	DRAFT: { variant: "secondary", key: "status-draft" },
+	PENDING: { variant: "outline", key: "status-pending" },
+	REJECTED: { variant: "destructive", key: "status-rejected" },
+	ARCHIVED: { variant: "secondary", key: "status-archived" },
+};
 
 export default async function MyPostsPage() {
 	const [t, user] = await Promise.all([
@@ -13,7 +27,7 @@ export default async function MyPostsPage() {
 	]);
 
 	if (!user?.id) {
-		redirect("/login");
+		redirect("/sign-in");
 	}
 
 	const posts = await getPosts({
@@ -27,11 +41,24 @@ export default async function MyPostsPage() {
 			{posts.length === 0 && (
 				<p className="text-muted-foreground">{t("you-have-no-posts")}</p>
 			)}
-			{posts.map((post) => (
-				<div key={post.id} data-post className="mb-4">
-					<PostDetails post={post} />
-				</div>
-			))}
+			{posts.map((post) => {
+				const statusConfig =
+					post.status && post.status !== "PUBLISHED"
+						? STATUS_CONFIG[post.status]
+						: null;
+				return (
+					<div key={post.id} data-post className="mb-4">
+						{statusConfig && (
+							<div className="mb-1 px-1">
+								<Badge variant={statusConfig.variant}>
+									{t(statusConfig.key as Parameters<typeof t>[0])}
+								</Badge>
+							</div>
+						)}
+						<PostDetails post={post} />
+					</div>
+				);
+			})}
 		</div>
 	);
 }

--- a/app/(home)/(private)/profile/edit-user/user-form.tsx
+++ b/app/(home)/(private)/profile/edit-user/user-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { User } from "@prisma/client";
+import { Foot, Position } from "@prisma/client";
 import { Loader2 } from "lucide-react";
 import Link from "next/dist/client/link";
 import { useTranslations } from "next-intl";
@@ -9,12 +10,42 @@ import { toast } from "sonner";
 import { InputLayout } from "@/components/layouts/input-layout";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { getUser } from "@/src/query/user.query";
 import { updateUser } from "./edit-user.action";
 import { userSchema } from "./user.schema";
+
+const ALL_POSITIONS = Object.values(Position);
+
+const toDisplayLabel = (value: string) =>
+	value
+		.replace(/_/g, " ")
+		.toLowerCase()
+		.replace(/\b\w/g, (c) => c.toUpperCase());
+
+const getFootValue = (foot: Foot[]): string => {
+	if (foot.includes(Foot.LEFT) && foot.includes(Foot.RIGHT)) return "BOTH";
+	if (foot.includes(Foot.LEFT)) return "LEFT";
+	if (foot.includes(Foot.RIGHT)) return "RIGHT";
+	return "";
+};
+
+const footValueToArray = (value: string): Foot[] => {
+	if (value === "BOTH") return [Foot.LEFT, Foot.RIGHT];
+	if (value === "LEFT") return [Foot.LEFT];
+	if (value === "RIGHT") return [Foot.RIGHT];
+	return [];
+};
 
 export const UserForm = ({ userId }: { userId: string }) => {
 	const t = useTranslations("profile.edit-user");
@@ -49,6 +80,15 @@ export const UserForm = ({ userId }: { userId: string }) => {
 			.finally(() => {
 				setIsLoading(false);
 			});
+	};
+
+	const togglePosition = (pos: Position) => {
+		if (!user) return;
+		const current = user.position ?? [];
+		const updated = current.includes(pos)
+			? current.filter((p) => p !== pos)
+			: [...current, pos];
+		setUser({ ...user, position: updated } as User);
 	};
 
 	return (
@@ -112,6 +152,59 @@ export const UserForm = ({ userId }: { userId: string }) => {
 						setUser({ ...user, biography: e.target.value } as User)
 					}
 				/>
+			</InputLayout>
+
+			<InputLayout>
+				<Label htmlFor="localisation">{t("localisation")}</Label>
+				<Input
+					type="text"
+					id="localisation"
+					placeholder={t("localisation-placeholder")}
+					value={user?.localisation || ""}
+					onChange={(e) =>
+						setUser({ ...user, localisation: e.target.value } as User)
+					}
+				/>
+			</InputLayout>
+
+			<InputLayout>
+				<Label>{t("position")}</Label>
+				<div className="grid grid-cols-2 gap-2 mt-1">
+					{ALL_POSITIONS.map((pos) => (
+						<div key={pos} className="flex items-center gap-2">
+							<Checkbox
+								id={`pos-${pos}`}
+								checked={(user?.position ?? []).includes(pos)}
+								onCheckedChange={() => togglePosition(pos)}
+							/>
+							<Label
+								htmlFor={`pos-${pos}`}
+								className="font-normal cursor-pointer"
+							>
+								{toDisplayLabel(pos)}
+							</Label>
+						</div>
+					))}
+				</div>
+			</InputLayout>
+
+			<InputLayout>
+				<Label htmlFor="foot">{t("foot")}</Label>
+				<Select
+					value={getFootValue(user?.foot ?? [])}
+					onValueChange={(value) =>
+						setUser({ ...user, foot: footValueToArray(value) } as User)
+					}
+				>
+					<SelectTrigger id="foot">
+						<SelectValue placeholder={t("foot-placeholder")} />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="LEFT">Left</SelectItem>
+						<SelectItem value="RIGHT">Right</SelectItem>
+						<SelectItem value="BOTH">Both</SelectItem>
+					</SelectContent>
+				</Select>
 			</InputLayout>
 
 			<Button className="w-full mt-2" type="submit" disabled={isLoading}>

--- a/app/(home)/(private)/profile/edit-user/user-form.tsx
+++ b/app/(home)/(private)/profile/edit-user/user-form.tsx
@@ -3,7 +3,7 @@
 import type { User } from "@prisma/client";
 import { Foot, Position } from "@prisma/client";
 import { Loader2 } from "lucide-react";
-import Link from "next/dist/client/link";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { type FormEvent, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -70,6 +70,7 @@ export const UserForm = ({ userId }: { userId: string }) => {
 
 		if (!parsedData.success) {
 			setError(parsedData.error.message);
+			setIsLoading(false);
 			return;
 		}
 
@@ -200,9 +201,9 @@ export const UserForm = ({ userId }: { userId: string }) => {
 						<SelectValue placeholder={t("foot-placeholder")} />
 					</SelectTrigger>
 					<SelectContent>
-						<SelectItem value="LEFT">Left</SelectItem>
-						<SelectItem value="RIGHT">Right</SelectItem>
-						<SelectItem value="BOTH">Both</SelectItem>
+						<SelectItem value="LEFT">{t("foot-left")}</SelectItem>
+						<SelectItem value="RIGHT">{t("foot-right")}</SelectItem>
+						<SelectItem value="BOTH">{t("foot-both")}</SelectItem>
 					</SelectContent>
 				</Select>
 			</InputLayout>

--- a/app/(home)/(private)/profile/edit-user/user.schema.ts
+++ b/app/(home)/(private)/profile/edit-user/user.schema.ts
@@ -1,3 +1,4 @@
+import { Foot, Position } from "@prisma/client";
 import { getTranslations } from "next-intl/server";
 import { z } from "zod";
 
@@ -9,6 +10,9 @@ export const createUserSchema = async () => {
 		fullName: z.string().min(1, { message: t("full-name-required") }),
 		biography: z.string().optional().nullable(),
 		birthday: z.date().optional().nullable(),
+		localisation: z.string().optional().nullable(),
+		position: z.array(z.nativeEnum(Position)).optional().default([]),
+		foot: z.array(z.nativeEnum(Foot)).optional().default([]),
 	});
 };
 
@@ -17,6 +21,9 @@ export const userSchema = z.object({
 	fullName: z.string(),
 	biography: z.string().optional().nullable(),
 	birthday: z.date().optional().nullable(),
+	localisation: z.string().optional().nullable(),
+	position: z.array(z.nativeEnum(Position)).optional().default([]),
+	foot: z.array(z.nativeEnum(Foot)).optional().default([]),
 });
 
 export type UserDataForm = z.infer<typeof userSchema>;

--- a/app/(home)/(private)/profile/favorites/favorites-list.tsx
+++ b/app/(home)/(private)/profile/favorites/favorites-list.tsx
@@ -29,7 +29,9 @@ export function FavoritesList({ posts, emptyLabel }: FavoritesListProps) {
 	return (
 		<div className="grid grid-cols-3 gap-1">
 			{posts.map((post) => {
-				const coverImage = post.medias.find((m) => m.type === "landingImage");
+				const coverImage =
+					post.medias.find((m) => m.type === "landingImage") ??
+					post.medias.find((m) => m.mimetype.startsWith("image/"));
 				return (
 					<Link
 						key={post.id}

--- a/app/(home)/(public)/contact/page.tsx
+++ b/app/(home)/(public)/contact/page.tsx
@@ -1,0 +1,29 @@
+import { MailIcon } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { Shell } from "@/components/shell";
+
+export default async function ContactPage() {
+	const t = await getTranslations("contact");
+
+	return (
+		<Shell>
+			<div className="container mx-auto px-4 py-16 max-w-2xl">
+				<h1 className="text-4xl font-bold tracking-tight mb-4">{t("title")}</h1>
+				<p className="text-lg text-muted-foreground mb-8">{t("description")}</p>
+
+				<div className="flex items-center gap-3 p-4 rounded-lg bg-muted">
+					<MailIcon className="h-5 w-5 text-muted-foreground shrink-0" />
+					<div>
+						<p className="text-sm text-muted-foreground">{t("email-label")}</p>
+						<a
+							href="mailto:contact@nfe-foot.com"
+							className="font-medium hover:underline"
+						>
+							contact@nfe-foot.com
+						</a>
+					</div>
+				</div>
+			</div>
+		</Shell>
+	);
+}

--- a/app/(home)/(public)/explore/explore-header.tsx
+++ b/app/(home)/(public)/explore/explore-header.tsx
@@ -67,22 +67,10 @@ export const ExploreHeader = () => {
 						{t("tabs.users")}
 					</TabsTrigger>
 					<TabsTrigger
-						value="hashtags"
-						className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
-					>
-						{t("tabs.hashtags")}
-					</TabsTrigger>
-					<TabsTrigger
 						value="posts"
 						className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
 					>
 						{t("tabs.posts")}
-					</TabsTrigger>
-					<TabsTrigger
-						value="events"
-						className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
-					>
-						{t("tabs.events")}
 					</TabsTrigger>
 				</TabsList>
 			</Tabs>

--- a/app/(home)/(public)/explore/explore-header.tsx
+++ b/app/(home)/(public)/explore/explore-header.tsx
@@ -34,10 +34,10 @@ export const ExploreHeader = () => {
 	};
 
 	return (
-		<header className="sticky top-0 z-40 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-			<div className="px-4 py-4">
-				<h1 className="text-2xl font-semibold mb-4">{t("title")}</h1>
-				<div className="relative mb-4">
+		<header className="sticky top-0 z-40 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border">
+			<div className="px-4 pt-4 pb-3">
+				<h1 className="text-2xl font-semibold mb-3">{t("title")}</h1>
+				<div className="relative">
 					<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 					<Input
 						type="search"
@@ -48,32 +48,35 @@ export const ExploreHeader = () => {
 					/>
 				</div>
 			</div>
-			<Tabs
-				value={tab}
-				onValueChange={(value) => navigateTo(q, value)}
-				className="w-full"
-			>
-				<TabsList className="w-full justify-between h-auto bg-transparent p-0 px-4">
-					<TabsTrigger
-						value="top"
-						className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
-					>
-						{t("tabs.top")}
-					</TabsTrigger>
-					<TabsTrigger
-						value="users"
-						className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
-					>
-						{t("tabs.users")}
-					</TabsTrigger>
-					<TabsTrigger
-						value="posts"
-						className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
-					>
-						{t("tabs.posts")}
-					</TabsTrigger>
-				</TabsList>
-			</Tabs>
+
+			{q && (
+				<Tabs
+					value={tab}
+					onValueChange={(value) => navigateTo(q, value)}
+					className="w-full"
+				>
+					<TabsList className="w-full justify-between h-auto bg-transparent p-0 px-4">
+						<TabsTrigger
+							value="top"
+							className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
+						>
+							{t("tabs.top")}
+						</TabsTrigger>
+						<TabsTrigger
+							value="users"
+							className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
+						>
+							{t("tabs.users")}
+						</TabsTrigger>
+						<TabsTrigger
+							value="posts"
+							className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
+						>
+							{t("tabs.posts")}
+						</TabsTrigger>
+					</TabsList>
+				</Tabs>
+			)}
 		</header>
 	);
 };

--- a/app/(home)/(public)/explore/page.tsx
+++ b/app/(home)/(public)/explore/page.tsx
@@ -1,7 +1,11 @@
 import { getTranslations } from "next-intl/server";
 import { UserResultItem } from "@/components/feature/search/user-result-item";
 import { searchPosts } from "@/src/query/post.query";
-import { searchUsers } from "@/src/query/user.query";
+import {
+	getSuggestedUsers,
+	getUserSessionId,
+	searchUsers,
+} from "@/src/query/user.query";
 import { ExploreHeader } from "./explore-header";
 import { ExplorePostResults } from "./explore-post-results";
 
@@ -22,11 +26,41 @@ export default async function Explore({
 			: Promise.resolve([]),
 	]);
 
+	let suggestedUsers: Awaited<ReturnType<typeof getSuggestedUsers>> = [];
+	if (!q) {
+		const uid = await getUserSessionId();
+		if (uid) suggestedUsers = await getSuggestedUsers(uid, 10);
+	}
+
 	return (
 		<div>
 			<ExploreHeader />
 			<div className="px-4 pb-4">
-				{!q && (
+				{!q && suggestedUsers.length > 0 && (
+					<div>
+						<h2 className="text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wide">
+							{t("suggested-users")}
+						</h2>
+						<div className="divide-y divide-border">
+							{suggestedUsers
+								.filter((u) => u.userType !== null)
+								.map((user) => (
+									<UserResultItem
+										key={user.id}
+										user={{
+											id: user.id,
+											name: user.name,
+											image: user.image,
+											// biome-ignore lint/style/noNonNullAssertion: filtered above
+											userType: user.userType!,
+										}}
+									/>
+								))}
+						</div>
+					</div>
+				)}
+
+				{!q && suggestedUsers.length === 0 && (
 					<p className="text-sm text-muted-foreground text-center py-12">
 						{t("empty-state")}
 					</p>

--- a/app/(home)/(public)/explore/page.tsx
+++ b/app/(home)/(public)/explore/page.tsx
@@ -1,4 +1,6 @@
 import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
+import { ExploreUserGrid } from "@/components/feature/search/suggested-user-card";
 import { UserResultItem } from "@/components/feature/search/user-result-item";
 import { searchPosts } from "@/src/query/post.query";
 import {
@@ -17,62 +19,50 @@ export default async function Explore({
 	const { q = "", tab = "top" } = await searchParams;
 	const t = await getTranslations("explore");
 
+	const showUsers = !!q && (tab === "top" || tab === "users");
+	const showPosts = !!q && (tab === "top" || tab === "posts");
+	const showSuggested = !q;
+
 	const [users, posts] = await Promise.all([
-		q && (tab === "top" || tab === "users")
-			? searchUsers(q)
-			: Promise.resolve([]),
-		q && (tab === "top" || tab === "posts")
-			? searchPosts(q)
-			: Promise.resolve([]),
+		showUsers ? searchUsers(q) : Promise.resolve([]),
+		showPosts ? searchPosts(q) : Promise.resolve([]),
 	]);
 
-	let suggestedUsers: Awaited<ReturnType<typeof getSuggestedUsers>> = [];
-	if (!q) {
-		const uid = await getUserSessionId();
-		if (uid) suggestedUsers = await getSuggestedUsers(uid, 10);
-	}
+	const suggestedUsers = showSuggested
+		? await getSuggestedUsers(await getUserSessionId(), 10)
+		: [];
+
+	const hasNoResults = !!q && users.length === 0 && posts.length === 0;
 
 	return (
 		<div>
-			<ExploreHeader />
-			<div className="px-4 pb-4">
-				{!q && suggestedUsers.length > 0 && (
+			<Suspense>
+				<ExploreHeader />
+			</Suspense>
+
+			<div className="px-4 pb-4 pt-4">
+				{showSuggested && suggestedUsers.length > 0 && (
 					<div>
-						<h2 className="text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wide">
+						<h2 className="text-sm font-semibold text-muted-foreground mb-3 uppercase tracking-wide">
 							{t("suggested-users")}
 						</h2>
-						<div className="divide-y divide-border">
-							{suggestedUsers
-								.filter((u) => u.userType !== null)
-								.map((user) => (
-									<UserResultItem
-										key={user.id}
-										user={{
-											id: user.id,
-											name: user.name,
-											image: user.image,
-											// biome-ignore lint/style/noNonNullAssertion: filtered above
-											userType: user.userType!,
-										}}
-									/>
-								))}
-						</div>
+						<ExploreUserGrid users={suggestedUsers} />
 					</div>
 				)}
 
-				{!q && suggestedUsers.length === 0 && (
+				{showSuggested && suggestedUsers.length === 0 && (
 					<p className="text-sm text-muted-foreground text-center py-12">
 						{t("empty-state")}
 					</p>
 				)}
 
-				{q && users.length === 0 && posts.length === 0 && (
+				{hasNoResults && (
 					<p className="text-sm text-muted-foreground text-center py-12">
 						{t("no-results", { query: q })}
 					</p>
 				)}
 
-				{q && (tab === "top" || tab === "users") && users.length > 0 && (
+				{showUsers && users.length > 0 && (
 					<div className="mb-6">
 						{tab === "top" && (
 							<h2 className="text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wide">
@@ -87,7 +77,7 @@ export default async function Explore({
 					</div>
 				)}
 
-				{q && (tab === "top" || tab === "posts") && posts.length > 0 && (
+				{showPosts && posts.length > 0 && (
 					<div>
 						{tab === "top" && (
 							<h2 className="text-sm font-semibold text-muted-foreground mb-2 uppercase tracking-wide">

--- a/app/(home)/(public)/page.tsx
+++ b/app/(home)/(public)/page.tsx
@@ -1,6 +1,9 @@
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
+import { UserSuggestions } from "@/components/feature/user/user-suggestions";
 import { getHasSeenSplash } from "@/src/actions/cookies.actions";
 import { getPostsWithCursor } from "@/src/query/post.query";
+import { getSuggestedUsers, getUserSessionId } from "@/src/query/user.query";
 import Posts from "./posts";
 
 export default async function Home() {
@@ -8,7 +11,31 @@ export default async function Home() {
 		return redirect("/splash");
 	}
 
-	const initialData = await getPostsWithCursor({});
+	const [initialData, userId] = await Promise.all([
+		getPostsWithCursor({}),
+		getUserSessionId(),
+	]);
 
-	return <Posts initialData={initialData} />;
+	const suggestedUsers = userId ? await getSuggestedUsers(userId, 3) : [];
+
+	return (
+		<div>
+			{suggestedUsers.length > 0 && (
+				<Suspense fallback={null}>
+					<div className="px-4 pt-4">
+						<UserSuggestions
+							users={suggestedUsers.map((u) => ({
+								id: u.id,
+								name: u.name ?? "",
+								image: u.image,
+								userType: u.userType ?? "",
+								position: u.position,
+							}))}
+						/>
+					</div>
+				</Suspense>
+			)}
+			<Posts initialData={initialData} />
+		</div>
+	);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@prisma/client": "^6.19.3",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-icons": "^1.3.2",
@@ -507,6 +508,8 @@
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 
     "@radix-ui/react-avatar": ["@radix-ui/react-avatar@1.1.11", "", { "dependencies": { "@radix-ui/react-context": "1.1.3", "@radix-ui/react-primitive": "2.1.4", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q=="],
+
+    "@radix-ui/react-checkbox": ["@radix-ui/react-checkbox@1.3.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw=="],
 
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
 

--- a/components/feature/search/suggested-user-card.tsx
+++ b/components/feature/search/suggested-user-card.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type { UserType } from "@prisma/client";
+import Link from "next/link";
+import { FollowButton } from "@/components/feature/follow/follow-button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { useSession } from "@/src/lib/auth-client";
+
+const USER_TYPE_LABELS: Record<UserType, string> = {
+	USER: "Utilisateur",
+	PLAYER: "Joueur",
+	COACH: "Entraîneur",
+	RECRUITER: "Recruteur",
+	CLUB: "Club",
+};
+
+interface SuggestedUser {
+	id: string;
+	name: string | null;
+	image: string | null;
+	userType: UserType;
+	position?: string[];
+	_count?: {
+		followeds: number;
+		posts: number;
+	};
+}
+
+export function SuggestedUserCard({ user }: { user: SuggestedUser }) {
+	const { data: session } = useSession();
+	const isPlayer = user.userType === "PLAYER";
+	const isLoggedIn = !!session?.user;
+
+	return (
+		<Card className="overflow-hidden transition-all duration-200 hover:border-primary/50 group bg-card border-border shadow-sm">
+			<CardContent className="p-4 flex flex-col items-center text-center gap-3">
+				<Link href={`/user/${user.id}`}>
+					<Avatar className="h-14 w-14 border-2 border-transparent group-hover:border-primary/20 transition-colors">
+						<AvatarImage src={user.image ?? ""} alt={user.name ?? ""} />
+						<AvatarFallback className="bg-muted text-muted-foreground uppercase">
+							{user.name?.[0] ?? "?"}
+						</AvatarFallback>
+					</Avatar>
+				</Link>
+
+				<div className="space-y-1 w-full">
+					<Link href={`/user/${user.id}`}>
+						<p className="font-semibold text-sm truncate leading-none hover:underline">
+							{user.name}
+						</p>
+					</Link>
+					<Badge
+						variant={isPlayer ? "default" : "secondary"}
+						className="text-[10px] uppercase tracking-wider px-1.5 py-0"
+					>
+						{USER_TYPE_LABELS[user.userType]}
+					</Badge>
+				</div>
+
+				{user._count && (
+					<div className="flex items-center justify-center gap-4 w-full text-xs text-muted-foreground">
+						<div className="flex flex-col items-center gap-0.5">
+							<span className="font-semibold text-foreground tabular-nums">
+								{user._count.followeds}
+							</span>
+							<span>abonnés</span>
+						</div>
+						<div className="w-px h-6 bg-border" />
+						<div className="flex flex-col items-center gap-0.5">
+							<span className="font-semibold text-foreground tabular-nums">
+								{user._count.posts}
+							</span>
+							<span>posts</span>
+						</div>
+					</div>
+				)}
+
+				<div className="w-full">
+					{isLoggedIn ? (
+						<FollowButton userId={user.id} showText={true} />
+					) : (
+						<Button variant="outline" size="sm" className="w-full" asChild>
+							<Link href={`/user/${user.id}`}>Voir le profil</Link>
+						</Button>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+export function ExploreUserGrid({ users }: { users: SuggestedUser[] }) {
+	return (
+		<div className="grid grid-cols-2 gap-3">
+			{users.map((user) => (
+				<SuggestedUserCard key={user.id} user={user} />
+			))}
+		</div>
+	);
+}

--- a/components/feature/search/suggested-user-card.tsx
+++ b/components/feature/search/suggested-user-card.tsx
@@ -2,20 +2,13 @@
 
 import type { UserType } from "@prisma/client";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { FollowButton } from "@/components/feature/follow/follow-button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { useSession } from "@/src/lib/auth-client";
-
-const USER_TYPE_LABELS: Record<UserType, string> = {
-	USER: "Utilisateur",
-	PLAYER: "Joueur",
-	COACH: "Entraîneur",
-	RECRUITER: "Recruteur",
-	CLUB: "Club",
-};
 
 interface SuggestedUser {
 	id: string;
@@ -31,6 +24,7 @@ interface SuggestedUser {
 
 export function SuggestedUserCard({ user }: { user: SuggestedUser }) {
 	const { data: session } = useSession();
+	const t = useTranslations("feature.search");
 	const isPlayer = user.userType === "PLAYER";
 	const isLoggedIn = !!session?.user;
 
@@ -56,7 +50,7 @@ export function SuggestedUserCard({ user }: { user: SuggestedUser }) {
 						variant={isPlayer ? "default" : "secondary"}
 						className="text-[10px] uppercase tracking-wider px-1.5 py-0"
 					>
-						{USER_TYPE_LABELS[user.userType]}
+						{t(`user-types.${user.userType}`)}
 					</Badge>
 				</div>
 
@@ -66,14 +60,14 @@ export function SuggestedUserCard({ user }: { user: SuggestedUser }) {
 							<span className="font-semibold text-foreground tabular-nums">
 								{user._count.followeds}
 							</span>
-							<span>abonnés</span>
+							<span>{t("followers")}</span>
 						</div>
 						<div className="w-px h-6 bg-border" />
 						<div className="flex flex-col items-center gap-0.5">
 							<span className="font-semibold text-foreground tabular-nums">
 								{user._count.posts}
 							</span>
-							<span>posts</span>
+							<span>{t("posts")}</span>
 						</div>
 					</div>
 				)}
@@ -83,7 +77,7 @@ export function SuggestedUserCard({ user }: { user: SuggestedUser }) {
 						<FollowButton userId={user.id} showText={true} />
 					) : (
 						<Button variant="outline" size="sm" className="w-full" asChild>
-							<Link href={`/user/${user.id}`}>Voir le profil</Link>
+							<Link href={`/user/${user.id}`}>{t("view-profile")}</Link>
 						</Button>
 					)}
 				</div>

--- a/components/feature/search/user-result-item.tsx
+++ b/components/feature/search/user-result-item.tsx
@@ -4,6 +4,15 @@ import type { UserType } from "@prisma/client";
 import Link from "next/link";
 import { FollowButton } from "@/components/feature/follow/follow-button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+
+const USER_TYPE_LABELS: Record<UserType, string> = {
+	USER: "Utilisateur",
+	PLAYER: "Joueur",
+	COACH: "Entraîneur",
+	RECRUITER: "Recruteur",
+	CLUB: "Club",
+};
 
 interface UserResultItemProps {
 	user: {
@@ -11,25 +20,47 @@ interface UserResultItemProps {
 		name: string | null;
 		image: string | null;
 		userType: UserType;
+		position?: string[];
 	};
 }
 
 export function UserResultItem({ user }: UserResultItemProps) {
+	const isPlayer = user.userType === "PLAYER";
+
 	return (
-		<div className="flex items-center gap-3 py-2">
-			<Link href={`/user/${user.id}`}>
-				<Avatar className="h-10 w-10">
-					<AvatarImage src={user.image ?? undefined} />
-					<AvatarFallback>
-						{user.name?.charAt(0).toUpperCase() ?? "?"}
+		<div className="flex items-center justify-between p-3 rounded-xl hover:bg-muted/50 transition-colors gap-3">
+			<Link
+				href={`/user/${user.id}`}
+				className="flex items-center gap-3 min-w-0"
+			>
+				<Avatar className="h-12 w-12 shrink-0 border border-border">
+					<AvatarImage src={user.image ?? ""} alt={user.name ?? ""} />
+					<AvatarFallback className="bg-muted text-muted-foreground">
+						{user.name?.[0] ?? "?"}
 					</AvatarFallback>
 				</Avatar>
+
+				<div className="flex flex-col gap-1 min-w-0">
+					<div className="flex items-center gap-2">
+						<span className="font-medium text-sm truncate">{user.name}</span>
+						<Badge
+							variant={isPlayer ? "default" : "outline"}
+							className="text-[9px] h-4 px-1 leading-none font-bold shrink-0"
+						>
+							{USER_TYPE_LABELS[user.userType]}
+						</Badge>
+					</div>
+					{user.position && user.position.length > 0 && (
+						<span className="text-xs text-muted-foreground truncate">
+							{user.position.join(" · ")}
+						</span>
+					)}
+				</div>
 			</Link>
-			<Link href={`/user/${user.id}`} className="flex-1 min-w-0">
-				<p className="font-medium text-sm truncate">{user.name}</p>
-				<p className="text-xs text-muted-foreground">{user.userType}</p>
-			</Link>
-			<FollowButton userId={user.id} showText={false} />
+
+			<div className="shrink-0">
+				<FollowButton userId={user.id} showText={false} />
+			</div>
 		</div>
 	);
 }

--- a/components/feature/search/user-result-item.tsx
+++ b/components/feature/search/user-result-item.tsx
@@ -2,17 +2,10 @@
 
 import type { UserType } from "@prisma/client";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { FollowButton } from "@/components/feature/follow/follow-button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-
-const USER_TYPE_LABELS: Record<UserType, string> = {
-	USER: "Utilisateur",
-	PLAYER: "Joueur",
-	COACH: "Entraîneur",
-	RECRUITER: "Recruteur",
-	CLUB: "Club",
-};
 
 interface UserResultItemProps {
 	user: {
@@ -25,6 +18,7 @@ interface UserResultItemProps {
 }
 
 export function UserResultItem({ user }: UserResultItemProps) {
+	const t = useTranslations("feature.search");
 	const isPlayer = user.userType === "PLAYER";
 
 	return (
@@ -47,7 +41,7 @@ export function UserResultItem({ user }: UserResultItemProps) {
 							variant={isPlayer ? "default" : "outline"}
 							className="text-[9px] h-4 px-1 leading-none font-bold shrink-0"
 						>
-							{USER_TYPE_LABELS[user.userType]}
+							{t(`user-types.${user.userType}`)}
 						</Badge>
 					</div>
 					{user.position && user.position.length > 0 && (

--- a/components/feature/user/user-profile.tsx
+++ b/components/feature/user/user-profile.tsx
@@ -160,7 +160,7 @@ export const UserProfile = ({
 								variant="outline"
 								size="icon"
 								asChild
-								title="Envoyer un message"
+								title={t("send-message")}
 							>
 								<Link href={`/messages/${user.id}`}>
 									<Mail className="h-4 w-4" />

--- a/components/feature/user/user-profile.tsx
+++ b/components/feature/user/user-profile.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { User } from "@prisma/client";
-import { Bookmark, Loader, Settings } from "lucide-react";
+import { Bookmark, Loader, MapPin, Settings } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import Posts from "@/app/(home)/(public)/posts";
 import { FollowButton } from "@/components/feature/follow/follow-button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -62,7 +63,51 @@ export const UserProfile = ({
 			<main className="pt-20 px-4">
 				<div className="text-center mb- 6">
 					<h1 className="text-2xl font-bold mb-1">{user.name}</h1>
-					<p className="text-muted-foreground mb-4">@{user.email}</p>
+					<p className="text-muted-foreground mb-2">@{user.email}</p>
+
+					{user.biography && (
+						<p className="text-sm text-center max-w-xs mx-auto mb-2">
+							{user.biography}
+						</p>
+					)}
+
+					{(user.localisation ||
+						user.birthday ||
+						user.position.length > 0 ||
+						user.foot.length > 0) && (
+						<div className="flex flex-wrap gap-2 justify-center mb-4">
+							{user.localisation && (
+								<Badge variant="secondary" className="flex items-center gap-1">
+									<MapPin className="h-3 w-3" />
+									{user.localisation}
+								</Badge>
+							)}
+							{user.birthday && (
+								<Badge variant="secondary">
+									{Math.floor(
+										(Date.now() - new Date(user.birthday).getTime()) /
+											(1000 * 60 * 60 * 24 * 365),
+									)}{" "}
+									{t("age")}
+								</Badge>
+							)}
+							{user.position.map((pos) => (
+								<Badge key={pos} variant="secondary">
+									{pos
+										.replace(/_/g, " ")
+										.toLowerCase()
+										.replace(/\b\w/g, (c) => c.toUpperCase())}
+								</Badge>
+							))}
+							{user.foot.length > 0 && (
+								<Badge variant="secondary">
+									{user.foot
+										.map((f) => f.charAt(0) + f.slice(1).toLowerCase())
+										.join(" / ")}
+								</Badge>
+							)}
+						</div>
+					)}
 
 					{isCurrentUser && (
 						<div className="flex justify-center gap-2">

--- a/components/feature/user/user-profile.tsx
+++ b/components/feature/user/user-profile.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { User } from "@prisma/client";
-import { Bookmark, Loader, MapPin, Settings } from "lucide-react";
+import { Bookmark, Loader, Mail, MapPin, Settings } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -61,9 +61,9 @@ export const UserProfile = ({
 			</div>
 
 			<main className="pt-20 px-4">
-				<div className="text-center mb- 6">
+				<div className="text-center mb-6">
 					<h1 className="text-2xl font-bold mb-1">{user.name}</h1>
-					<p className="text-muted-foreground mb-2">@{user.email}</p>
+					<p className="text-muted-foreground mb-2">@{user.name}</p>
 
 					{user.biography && (
 						<p className="text-sm text-center max-w-xs mx-auto mb-2">
@@ -154,7 +154,19 @@ export const UserProfile = ({
 					)}
 
 					{!isCurrentUser && userIdSession && (
-						<FollowButton userId={user.id} showText={true} />
+						<div className="flex items-center justify-center gap-2">
+							<FollowButton userId={user.id} showText={true} />
+							<Button
+								variant="outline"
+								size="icon"
+								asChild
+								title="Envoyer un message"
+							>
+								<Link href={`/messages/${user.id}`}>
+									<Mail className="h-4 w-4" />
+								</Link>
+							</Button>
+						</div>
 					)}
 				</div>
 

--- a/components/feature/user/user-suggestions.tsx
+++ b/components/feature/user/user-suggestions.tsx
@@ -3,6 +3,7 @@
 import { MoreHorizontal, X } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+import { FollowButton } from "@/components/feature/follow/follow-button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -48,7 +49,7 @@ export function UserSuggestions({ users, onClose }: UserSuggestionsProps) {
 				{users.map((user) => (
 					<div key={user.id} className="flex items-center justify-between">
 						<div className="flex items-center gap-3">
-							<Link href={`/profile/${user.id}`}>
+							<Link href={`/user/${user.id}`}>
 								<Avatar>
 									<AvatarImage src={user.image || ""} alt={user.name} />
 									<AvatarFallback>{user.name[0]}</AvatarFallback>
@@ -56,7 +57,7 @@ export function UserSuggestions({ users, onClose }: UserSuggestionsProps) {
 							</Link>
 							<div>
 								<Link
-									href={`/profile/${user.id}`}
+									href={`/user/${user.id}`}
 									className="font-semibold hover:underline"
 								>
 									{user.name}
@@ -69,9 +70,7 @@ export function UserSuggestions({ users, onClose }: UserSuggestionsProps) {
 								)}
 							</div>
 						</div>
-						<Button variant="outline" size="sm">
-							{t("connect")}
-						</Button>
+						<FollowButton userId={user.id} showText={true} />
 					</div>
 				))}
 			</div>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+	"inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+	{
+		variants: {
+			variant: {
+				default:
+					"border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+				secondary:
+					"border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+				destructive:
+					"border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+				outline: "text-foreground",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	},
+);
+
+export interface BadgeProps
+	extends React.HTMLAttributes<HTMLDivElement>,
+		VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+	return (
+		<div className={cn(badgeVariants({ variant }), className)} {...props} />
+	);
+}
+
+export { Badge, badgeVariants };

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Checkbox = React.forwardRef<
+	React.ComponentRef<typeof CheckboxPrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+	<CheckboxPrimitive.Root
+		ref={ref}
+		className={cn(
+			"peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+			className,
+		)}
+		{...props}
+	>
+		<CheckboxPrimitive.Indicator
+			className={cn("flex items-center justify-center text-current")}
+		>
+			<Check className="h-4 w-4" />
+		</CheckboxPrimitive.Indicator>
+	</CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/messages/en.json
+++ b/messages/en.json
@@ -8,6 +8,7 @@
 		"placeholder": "Search players, clubs...",
 		"no-results": "No results for \"{query}\"",
 		"empty-state": "Search for players, coaches, clubs...",
+		"suggested-users": "Suggested users",
 		"tabs": {
 			"top": "Top",
 			"users": "Users",
@@ -117,7 +118,12 @@
 		},
 		"my-posts": {
 			"my-posts": "My Posts",
-			"you-have-no-posts": "You have no posts"
+			"you-have-no-posts": "You have no posts",
+			"status-published": "Published",
+			"status-draft": "Draft",
+			"status-pending": "Pending review",
+			"status-rejected": "Rejected",
+			"status-archived": "Archived"
 		}
 	},
 	"header": {
@@ -310,6 +316,30 @@
 			"previous": "Previous",
 			"next": "Next",
 			"page": "Page"
+		},
+		"signals": "Reported Posts",
+		"moderation": {
+			"title": "Reported Posts",
+			"description": "Posts flagged by users for review",
+			"pending": "Pending",
+			"reviewed": "Reviewed",
+			"dismissed": "Dismissed",
+			"reason": "Reason",
+			"reporter": "Reported by",
+			"reported-at": "Reported at",
+			"post": "Post",
+			"keep-post": "Keep Post",
+			"reject-post": "Reject Post",
+			"dismiss": "Dismiss",
+			"post-kept": "Post kept, signal marked reviewed",
+			"post-rejected": "Post rejected",
+			"signal-dismissed": "Signal dismissed",
+			"no-signals": "No reports in this category",
+			"reason-inappropriate": "Inappropriate",
+			"reason-spam": "Spam",
+			"reason-offensive": "Offensive",
+			"reason-misleading": "Misleading",
+			"reason-other": "Other"
 		}
 	},
 	"onboarding": {
@@ -380,6 +410,12 @@
 			"full-name": "Full name",
 			"birthday": "Birthday",
 			"biography": "Biography",
+			"localisation": "City",
+			"position": "Position",
+			"foot": "Preferred foot",
+			"localisation-placeholder": "Enter your city",
+			"position-placeholder": "Select your positions",
+			"foot-placeholder": "Select your preferred foot",
 			"invalid-email": "Invalid email address",
 			"full-name-required": "Full name is required",
 			"save": "Save",
@@ -414,7 +450,12 @@
 				"confirm-delete-account": "Are you sure you want to delete your account? This action cannot be undone.",
 				"account-deleted-successfully": "Account deleted successfully",
 				"failed-to-delete-account": "Failed to delete account",
-				"delete-account": "Delete Account"
+				"delete-account": "Delete Account",
+				"biography": "Biography",
+				"localisation": "City",
+				"position": "Position",
+				"foot": "Preferred foot",
+				"age": "Age"
 			},
 			"suggestions": {
 				"suggestions": "Suggestions",
@@ -459,5 +500,11 @@
 		"messages": {
 			"user-not-authenticated": "User not authenticated"
 		}
+	},
+	"contact": {
+		"title": "Contact Us",
+		"email-label": "Email",
+		"description": "Have a question or feedback? Reach out to us at the address below.",
+		"social-title": "Follow us"
 	}
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -339,7 +339,11 @@
 			"reason-spam": "Spam",
 			"reason-offensive": "Offensive",
 			"reason-misleading": "Misleading",
-			"reason-other": "Other"
+			"reason-other": "Other",
+			"unauthorized": "Unauthorized",
+			"review-failed": "Failed to review signal",
+			"dismiss-failed": "Failed to dismiss signal",
+			"reject-failed": "Failed to reject post"
 		}
 	},
 	"onboarding": {
@@ -420,7 +424,10 @@
 			"full-name-required": "Full name is required",
 			"save": "Save",
 			"back-to-profile": "Back to profile",
-			"change-password": "Change Password"
+			"change-password": "Change Password",
+			"foot-left": "Left",
+			"foot-right": "Right",
+			"foot-both": "Both"
 		}
 	},
 	"auth": {
@@ -455,7 +462,20 @@
 				"localisation": "City",
 				"position": "Position",
 				"foot": "Preferred foot",
-				"age": "Age"
+				"age": "Age",
+				"send-message": "Send a message"
+			},
+			"search": {
+				"view-profile": "View profile",
+				"followers": "followers",
+				"posts": "posts",
+				"user-types": {
+					"USER": "User",
+					"PLAYER": "Player",
+					"COACH": "Coach",
+					"RECRUITER": "Recruiter",
+					"CLUB": "Club"
+				}
 			},
 			"suggestions": {
 				"suggestions": "Suggestions",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -339,7 +339,11 @@
 			"reason-spam": "Spam",
 			"reason-offensive": "Offensant",
 			"reason-misleading": "Trompeur",
-			"reason-other": "Autre"
+			"reason-other": "Autre",
+			"unauthorized": "Non autorisé",
+			"review-failed": "Échec de l'examen du signalement",
+			"dismiss-failed": "Échec de la suppression du signalement",
+			"reject-failed": "Échec du rejet du post"
 		}
 	},
 	"onboarding": {
@@ -420,7 +424,10 @@
 			"full-name-required": "Le nom complet est requis",
 			"save": "Enregistrer",
 			"back-to-profile": "Retour au profil",
-			"change-password": "Changer le mot de passe"
+			"change-password": "Changer le mot de passe",
+			"foot-left": "Gauche",
+			"foot-right": "Droite",
+			"foot-both": "Les deux"
 		}
 	},
 	"auth": {
@@ -455,7 +462,20 @@
 				"localisation": "Ville",
 				"position": "Poste",
 				"foot": "Pied préféré",
-				"age": "Âge"
+				"age": "Âge",
+				"send-message": "Envoyer un message"
+			},
+			"search": {
+				"view-profile": "Voir le profil",
+				"followers": "abonnés",
+				"posts": "posts",
+				"user-types": {
+					"USER": "Utilisateur",
+					"PLAYER": "Joueur",
+					"COACH": "Entraîneur",
+					"RECRUITER": "Recruteur",
+					"CLUB": "Club"
+				}
 			},
 			"suggestions": {
 				"suggestions": "Suggestions",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -8,6 +8,7 @@
 		"placeholder": "Rechercher des joueurs, clubs...",
 		"no-results": "Aucun résultat pour « {query} »",
 		"empty-state": "Recherchez des joueurs, entraîneurs, clubs...",
+		"suggested-users": "Utilisateurs suggérés",
 		"tabs": {
 			"top": "Top",
 			"users": "Utilisateurs",
@@ -117,7 +118,12 @@
 		},
 		"my-posts": {
 			"my-posts": "Mes Posts",
-			"you-have-no-posts": "Vous n'avez pas de posts"
+			"you-have-no-posts": "Vous n'avez pas de posts",
+			"status-published": "Publié",
+			"status-draft": "Brouillon",
+			"status-pending": "En attente",
+			"status-rejected": "Rejeté",
+			"status-archived": "Archivé"
 		}
 	},
 	"header": {
@@ -310,6 +316,30 @@
 			"previous": "Précédent",
 			"next": "Suivant",
 			"page": "Page"
+		},
+		"signals": "Signalements",
+		"moderation": {
+			"title": "Posts signalés",
+			"description": "Posts signalés par les utilisateurs pour examen",
+			"pending": "En attente",
+			"reviewed": "Examiné",
+			"dismissed": "Ignoré",
+			"reason": "Raison",
+			"reporter": "Signalé par",
+			"reported-at": "Signalé le",
+			"post": "Publication",
+			"keep-post": "Garder le post",
+			"reject-post": "Rejeter le post",
+			"dismiss": "Ignorer",
+			"post-kept": "Post conservé, signalement marqué comme examiné",
+			"post-rejected": "Post rejeté",
+			"signal-dismissed": "Signalement ignoré",
+			"no-signals": "Aucun signalement dans cette catégorie",
+			"reason-inappropriate": "Inapproprié",
+			"reason-spam": "Spam",
+			"reason-offensive": "Offensant",
+			"reason-misleading": "Trompeur",
+			"reason-other": "Autre"
 		}
 	},
 	"onboarding": {
@@ -380,6 +410,12 @@
 			"full-name": "Nom complet",
 			"birthday": "Date de naissance",
 			"biography": "Biographie",
+			"localisation": "Ville",
+			"position": "Poste",
+			"foot": "Pied préféré",
+			"localisation-placeholder": "Entrez votre ville",
+			"position-placeholder": "Sélectionnez vos postes",
+			"foot-placeholder": "Sélectionnez votre pied préféré",
 			"invalid-email": "Adresse email invalide",
 			"full-name-required": "Le nom complet est requis",
 			"save": "Enregistrer",
@@ -414,7 +450,12 @@
 				"confirm-delete-account": "Êtes-vous sûr de vouloir supprimer votre compte ? Cette action ne peut pas être annulée.",
 				"account-deleted-successfully": "Compte supprimé avec succès",
 				"failed-to-delete-account": "Échec de la suppression du compte",
-				"delete-account": "Supprimer le compte"
+				"delete-account": "Supprimer le compte",
+				"biography": "Biographie",
+				"localisation": "Ville",
+				"position": "Poste",
+				"foot": "Pied préféré",
+				"age": "Âge"
 			},
 			"suggestions": {
 				"suggestions": "Suggestions",
@@ -459,5 +500,11 @@
 		"messages": {
 			"user-not-authenticated": "Utilisateur non authentifié"
 		}
+	},
+	"contact": {
+		"title": "Nous contacter",
+		"email-label": "Email",
+		"description": "Une question ou un retour ? Contactez-nous à l'adresse ci-dessous.",
+		"social-title": "Suivez-nous"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"@prisma/client": "^6.19.3",
 		"@radix-ui/react-alert-dialog": "^1.1.15",
 		"@radix-ui/react-avatar": "^1.1.11",
+		"@radix-ui/react-checkbox": "^1.3.3",
 		"@radix-ui/react-dialog": "^1.1.15",
 		"@radix-ui/react-dropdown-menu": "^2.1.16",
 		"@radix-ui/react-icons": "^1.3.2",

--- a/prisma/seeds.ts
+++ b/prisma/seeds.ts
@@ -1,7 +1,12 @@
 import { PrismaClient } from "@prisma/client";
+import { seedComments } from "./seeds/comments";
+import { seedFavorites } from "./seeds/favorites";
+import { seedFollows } from "./seeds/follows";
+import { seedLikes } from "./seeds/likes";
 import { seedMedias } from "./seeds/medias";
 import { seedMessages } from "./seeds/messages";
 import { seedPosts } from "./seeds/posts";
+import { seedSignals } from "./seeds/signals";
 import { seedUsers } from "./seeds/users";
 
 const prisma = new PrismaClient();
@@ -10,7 +15,12 @@ const main = async () => {
 	const users = await seedUsers(prisma);
 	const posts = await seedPosts({ prisma, users });
 	await seedMedias({ prisma, posts });
+	await seedFollows({ prisma, users });
 	await seedMessages({ prisma, users });
+	await seedSignals({ prisma, posts, users });
+	await seedLikes({ prisma, posts, users });
+	await seedComments({ prisma, posts, users });
+	await seedFavorites({ prisma, posts, users });
 };
 
 main()

--- a/prisma/seeds/comments.ts
+++ b/prisma/seeds/comments.ts
@@ -1,0 +1,41 @@
+import { faker } from "@faker-js/faker/locale/fr";
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+export const seedComments = async ({
+	prisma,
+	posts,
+	users,
+}: {
+	prisma: PrismaClient;
+	posts: Prisma.PostUncheckedCreateInput[];
+	users: Prisma.UserCreateInput[];
+}) => {
+	const publishedPosts = posts.filter(
+		(p) => p.id && p.status === "PUBLISHED",
+	) as (Prisma.PostUncheckedCreateInput & { id: string })[];
+
+	const usersWithId = users.filter((u) => u.id) as (Prisma.UserCreateInput & {
+		id: string;
+	})[];
+
+	if (publishedPosts.length === 0 || usersWithId.length === 0) return;
+
+	for (const post of publishedPosts) {
+		const nbComments = Math.floor(Math.random() * 6);
+		const candidates = [...usersWithId].sort(() => Math.random() - 0.5);
+
+		for (let i = 0; i < Math.min(nbComments, candidates.length); i++) {
+			const user = candidates[i];
+			if (!user) continue;
+
+			await prisma.comment.create({
+				data: {
+					postId: post.id,
+					userId: user.id,
+					content: faker.lorem.sentence(),
+					createdAt: faker.date.recent({ days: 30 }),
+				},
+			});
+		}
+	}
+};

--- a/prisma/seeds/favorites.ts
+++ b/prisma/seeds/favorites.ts
@@ -1,0 +1,41 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+export const seedFavorites = async ({
+	prisma,
+	posts,
+	users,
+}: {
+	prisma: PrismaClient;
+	posts: Prisma.PostUncheckedCreateInput[];
+	users: Prisma.UserCreateInput[];
+}) => {
+	const publishedPosts = posts.filter(
+		(p) => p.id && p.status === "PUBLISHED",
+	) as (Prisma.PostUncheckedCreateInput & { id: string })[];
+
+	const usersWithId = users.filter((u) => u.id) as (Prisma.UserCreateInput & {
+		id: string;
+	})[];
+
+	if (publishedPosts.length === 0 || usersWithId.length === 0) return;
+
+	const favorited = new Set<string>();
+
+	for (const user of usersWithId) {
+		const nbFavorites = Math.floor(Math.random() * 5);
+		const candidates = [...publishedPosts].sort(() => Math.random() - 0.5);
+
+		for (let i = 0; i < Math.min(nbFavorites, candidates.length); i++) {
+			const post = candidates[i];
+			if (!post) continue;
+
+			const key = `${post.id}:${user.id}`;
+			if (favorited.has(key)) continue;
+			favorited.add(key);
+
+			await prisma.favorite.create({
+				data: { postId: post.id, userId: user.id },
+			});
+		}
+	}
+};

--- a/prisma/seeds/follows.ts
+++ b/prisma/seeds/follows.ts
@@ -1,0 +1,38 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+export const seedFollows = async ({
+	prisma,
+	users,
+}: {
+	prisma: PrismaClient;
+	users: Prisma.UserCreateInput[];
+}) => {
+	const usersWithId = users.filter((u) => u.id) as (Prisma.UserCreateInput & {
+		id: string;
+	})[];
+
+	if (usersWithId.length < 2) return;
+
+	const followed = new Set<string>();
+
+	for (const user of usersWithId) {
+		const nbFollowing = Math.floor(Math.random() * 8) + 2;
+		const candidates = usersWithId.filter((u) => u.id !== user.id);
+
+		for (let i = 0; i < Math.min(nbFollowing, candidates.length); i++) {
+			const target = candidates[Math.floor(Math.random() * candidates.length)];
+			if (!target) continue;
+
+			const key = `${user.id}:${target.id}`;
+			if (followed.has(key)) continue;
+			followed.add(key);
+
+			await prisma.follow.create({
+				data: {
+					followerId: user.id,
+					followingId: target.id,
+				},
+			});
+		}
+	}
+};

--- a/prisma/seeds/likes.ts
+++ b/prisma/seeds/likes.ts
@@ -1,0 +1,41 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+export const seedLikes = async ({
+	prisma,
+	posts,
+	users,
+}: {
+	prisma: PrismaClient;
+	posts: Prisma.PostUncheckedCreateInput[];
+	users: Prisma.UserCreateInput[];
+}) => {
+	const publishedPosts = posts.filter(
+		(p) => p.id && p.status === "PUBLISHED",
+	) as (Prisma.PostUncheckedCreateInput & { id: string })[];
+
+	const usersWithId = users.filter((u) => u.id) as (Prisma.UserCreateInput & {
+		id: string;
+	})[];
+
+	if (publishedPosts.length === 0 || usersWithId.length === 0) return;
+
+	const liked = new Set<string>();
+
+	for (const post of publishedPosts) {
+		const nbLikes = Math.floor(Math.random() * 9);
+		const candidates = [...usersWithId].sort(() => Math.random() - 0.5);
+
+		for (let i = 0; i < Math.min(nbLikes, candidates.length); i++) {
+			const user = candidates[i];
+			if (!user) continue;
+
+			const key = `${post.id}:${user.id}`;
+			if (liked.has(key)) continue;
+			liked.add(key);
+
+			await prisma.like.create({
+				data: { postId: post.id, userId: user.id },
+			});
+		}
+	}
+};

--- a/prisma/seeds/medias.ts
+++ b/prisma/seeds/medias.ts
@@ -1,5 +1,10 @@
 import { faker } from "@faker-js/faker/locale/fr";
-import type { Media, Prisma, PrismaClient } from "@prisma/client";
+import {
+	type Media,
+	MediaType,
+	type Prisma,
+	type PrismaClient,
+} from "@prisma/client";
 import { randomizer } from "../../src/lib/array";
 
 export const seedMedias = async ({
@@ -29,6 +34,7 @@ export const seedMedias = async ({
 				...data,
 				url: video,
 				mimetype: "video/mp4",
+				type: MediaType.mainVideo,
 				metadata: {
 					video: { duration: Math.floor(Math.random() * 120) + 15 },
 				},
@@ -40,6 +46,7 @@ export const seedMedias = async ({
 				...data,
 				url: image,
 				mimetype: "image/jpeg",
+				type: MediaType.landingImage,
 				metadata: { image: { width: 1280, height: 720 } },
 			},
 		});

--- a/prisma/seeds/medias.ts
+++ b/prisma/seeds/medias.ts
@@ -27,14 +27,10 @@ export const seedMedias = async ({
 		const dbVideo = await prisma.media.create({
 			data: {
 				...data,
-				...{
-					url: video,
-					mimetype: "video/mp4",
-					metadata: {
-						video: {
-							duration: 100,
-						},
-					},
+				url: video,
+				mimetype: "video/mp4",
+				metadata: {
+					video: { duration: Math.floor(Math.random() * 120) + 15 },
 				},
 			},
 		});
@@ -42,16 +38,9 @@ export const seedMedias = async ({
 		const dbImage = await prisma.media.create({
 			data: {
 				...data,
-				...{
-					url: image,
-					mimetype: "image/jpeg",
-					metadata: {
-						image: {
-							width: 100,
-							height: 100,
-						},
-					},
-				},
+				url: image,
+				mimetype: "image/jpeg",
+				metadata: { image: { width: 1280, height: 720 } },
 			},
 		});
 
@@ -61,25 +50,35 @@ export const seedMedias = async ({
 	return medias;
 };
 
+const FOOTBALL_VIDEOS = [
+	"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+	"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
+	"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4",
+	"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4",
+	"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4",
+	"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4",
+	"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/VolkswagenGTIReview.mp4",
+	"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/WeAreGoingOnBullrun.mp4",
+];
+
+const FOOTBALL_THUMBNAILS = [
+	"https://images.unsplash.com/photo-1579952363873-27f3bade9f55?w=1280&h=720&fit=crop",
+	"https://images.unsplash.com/photo-1552667466-07770ae110d0?w=1280&h=720&fit=crop",
+	"https://images.unsplash.com/photo-1574629810360-7efbbe195018?w=1280&h=720&fit=crop",
+	"https://images.unsplash.com/photo-1504305754058-2f08ccd89a0a?w=1280&h=720&fit=crop",
+	"https://images.unsplash.com/photo-1459865264687-595d652de67e?w=1280&h=720&fit=crop",
+	"https://images.unsplash.com/photo-1551958219-acbc595b8b7a?w=1280&h=720&fit=crop",
+	"https://images.unsplash.com/photo-1431324155629-1a6deb1dec8d?w=1280&h=720&fit=crop",
+	"https://images.unsplash.com/photo-1540747913346-19e32dc3e97e?w=1280&h=720&fit=crop",
+	"https://images.unsplash.com/photo-1560272564-c83b66b1ad12?w=1280&h=720&fit=crop",
+	"https://images.unsplash.com/photo-1606925797300-0b35e9d1794e?w=1280&h=720&fit=crop",
+	"https://images.unsplash.com/photo-1517466787929-bc90951d0974?w=1280&h=720&fit=crop",
+	"https://images.unsplash.com/photo-1543326727-cf6c39e8f84c?w=1280&h=720&fit=crop",
+];
+
 const randomVideo = (): { video: string; image: string } => {
-	return randomizer([
-		{
-			video:
-				"https://console-oog0coc0cc4ccss80ocwckk4.145.223.81.185.sslip.io/api/v1/download-shared-object/aHR0cHM6Ly9taW5pby1vb2cwY29jMGNjNGNjc3M4MG9jd2NrazQuMTQ1LjIyMy44MS4xODUuc3NsaXAuaW8vbmZlLXdlYmFwcC9DJTI3ZXN0JTIwbGUlMjBHRU5JRSUyMGR1JTIwZm9vdGJhbGwlMjBhbWF0ZXVyJTIwJUYwJTlGJUFBJTg0JTIwJTIwLSUyMExlJTIwWkFQJTIwZHUlMjB3ZWVrLWVuZCUyMCUyODIwJUUyJUE3JUI4MDklMjkubXA0P1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9WkFaNzdNT0ZEWjBYQjNFSlM5R0ElMkYyMDI0MTIwMSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDEyMDFUMTgzMDU4WiZYLUFtei1FeHBpcmVzPTQzMjAwJlgtQW16LVNlY3VyaXR5LVRva2VuPWV5SmhiR2NpT2lKSVV6VXhNaUlzSW5SNWNDSTZJa3BYVkNKOS5leUpoWTJObGMzTkxaWGtpT2lKYVFWbzNOMDFQUmtSYU1GaENNMFZLVXpsSFFTSXNJbVY0Y0NJNk1UY3pNekV5TURZMU1Dd2ljR0Z5Wlc1MElqb2libVpsSW4wLjVPWlhlRlROd3NpTjJqenROOWlkbTh3NnJZbjhNV3RRNHhpZFpNMGN5UE1XaFVSNGxXNHptVzJiNExMMXpNYmEzc0lxcTMtajJSUlVWYVVHQzMyVEZ3JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZ2ZXJzaW9uSWQ9bnVsbCZYLUFtei1TaWduYXR1cmU9MGVlZDVlMmIyYTIyZDg0ZTMzNzQ0ZTM1MDQ5YjUwMjQ5MDg2MjQxYjg1NzI2NDQ2MmI2MDAxOWRkMDliODAwOQ",
-			image:
-				"https://images.unsplash.com/photo-1504305754058-2f08ccd89a0a?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		},
-		{
-			video:
-				"https://console-oog0coc0cc4ccss80ocwckk4.145.223.81.185.sslip.io/api/v1/buckets/nfe-webapp/objects/download?preview=true&prefix=C%27est%20le%20GENIE%20du%20football%20amateur%20%F0%9F%AA%84%20%20-%20Le%20ZAP%20du%20week-end%20(20%E2%A7%B809).mp4",
-			image:
-				"https://images.unsplash.com/photo-1504305754058-2f08ccd89a0a?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		},
-		{
-			video:
-				"https://console-oog0coc0cc4ccss80ocwckk4.145.223.81.185.sslip.io/api/v1/download-shared-object/aHR0cHM6Ly9taW5pby1vb2cwY29jMGNjNGNjc3M4MG9jd2NrazQuMTQ1LjIyMy44MS4xODUuc3NsaXAuaW8vbmZlLXdlYmFwcC9DJTI3ZXN0JTIwbGUlMjBHRU5JRSUyMGR1JTIwZm9vdGJhbGwlMjBhbWF0ZXVyJTIwJUYwJTlGJUFBJTg0JTIwJTIwLSUyMExlJTIwWkFQJTIwZHUlMjB3ZWVrLWVuZCUyMCUyODIwJUUyJUE3JUI4MDklMjklMjAlMjgzJTI5Lm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPVpBWjc3TU9GRFowWEIzRUpTOUdBJTJGMjAyNDEyMDElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMjAxVDIwMDEzN1omWC1BbXotRXhwaXJlcz00MzIwMCZYLUFtei1TZWN1cml0eS1Ub2tlbj1leUpoYkdjaU9pSklVelV4TWlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKaFkyTmxjM05MWlhraU9pSmFRVm8zTjAxUFJrUmFNRmhDTTBWS1V6bEhRU0lzSW1WNGNDSTZNVGN6TXpFeU1EWTFNQ3dpY0dGeVpXNTBJam9pYm1abEluMC41T1pYZUZUTndzaU4yanp0TjlpZG04dzZyWW44TVd0UTR4aWRaTTBjeVBNV2hVUjRsVzR6bVcyYjRMTDF6TWJhM3NJcXEzLWoyUlJVVmFVR0MzMlRGdyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmdmVyc2lvbklkPW51bGwmWC1BbXotU2lnbmF0dXJlPTEwNDFmZGQxNThhMTNlZmY0MDJiYmU2MGE4YzEwNWNmMDIxMGQwMjRhNzQ5OGE1ZmE3NGI4ZDA5Zjg2MzhlYzg",
-			image:
-				"https://images.unsplash.com/photo-1504305754058-2f08ccd89a0a?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-		},
-	]) as { video: string; image: string };
+	return {
+		video: randomizer(FOOTBALL_VIDEOS) as string,
+		image: randomizer(FOOTBALL_THUMBNAILS) as string,
+	};
 };

--- a/prisma/seeds/posts.ts
+++ b/prisma/seeds/posts.ts
@@ -1,5 +1,10 @@
 import { faker } from "@faker-js/faker/locale/fr";
-import { type Prisma, type PrismaClient, SpamScore } from "@prisma/client";
+import {
+	PostStatus,
+	type Prisma,
+	type PrismaClient,
+	SpamScore,
+} from "@prisma/client";
 import { randomizer } from "../../src/lib/array";
 
 export const seedPosts = async ({
@@ -11,7 +16,7 @@ export const seedPosts = async ({
 }) => {
 	const posts: Prisma.PostUncheckedCreateInput[] = [];
 	for (const user of users) {
-		const nbPosts = Math.floor(Math.random() * 5) + 1;
+		const nbPosts = Math.floor(Math.random() * 8) + 3;
 
 		for (let i = 0; i < nbPosts; i++) {
 			const dbPost = await prisma.post.create({ data: postData(user) });
@@ -31,17 +36,17 @@ function postData(
 
 	const createdAt = faker.date.past();
 	const spamScore = getSpamScore();
+	const status = getPostStatus();
 
 	return {
 		createdAt,
 		spamScore,
+		status,
 		updatedAt: faker.date.between({ from: createdAt, to: new Date() }),
-		// expires  after 30 days from creation
 		expiresAt: faker.date.between({
 			from: createdAt,
 			to: new Date(createdAt.getTime() + 30 * 24 * 60 * 60 * 1000),
 		}),
-		// if suspect, set a validation date in 1 day after creation
 		validatedAt:
 			spamScore === SpamScore.SUSPECT
 				? faker.date.between({
@@ -54,6 +59,19 @@ function postData(
 		description: faker.lorem.paragraphs(),
 		userId: user.id,
 	} satisfies Prisma.PostUncheckedCreateInput;
+}
+
+function getPostStatus(): PostStatus {
+	return randomizer([
+		PostStatus.PUBLISHED,
+		PostStatus.PUBLISHED,
+		PostStatus.PUBLISHED,
+		PostStatus.PUBLISHED,
+		PostStatus.PUBLISHED,
+		PostStatus.DRAFT,
+		PostStatus.PENDING,
+		PostStatus.REJECTED,
+	]) as PostStatus;
 }
 
 function getSpamScore(): SpamScore | undefined {

--- a/prisma/seeds/signals.ts
+++ b/prisma/seeds/signals.ts
@@ -1,0 +1,62 @@
+import { faker } from "@faker-js/faker/locale/fr";
+import {
+	type Prisma,
+	type PrismaClient,
+	SignalReason,
+	SignalStatus,
+} from "@prisma/client";
+import { randomizer } from "../../src/lib/array";
+
+const ALL_REASONS = Object.values(SignalReason);
+const ALL_STATUSES = [
+	SignalStatus.PENDING,
+	SignalStatus.PENDING,
+	SignalStatus.PENDING,
+	SignalStatus.REVIEWED,
+	SignalStatus.DISMISSED,
+];
+
+export const seedSignals = async ({
+	prisma,
+	posts,
+	users,
+}: {
+	prisma: PrismaClient;
+	posts: Prisma.PostUncheckedCreateInput[];
+	users: Prisma.UserCreateInput[];
+}) => {
+	const postsWithId = posts.filter(
+		(p) => p.id,
+	) as (Prisma.PostUncheckedCreateInput & { id: string })[];
+	const usersWithId = users.filter((u) => u.id) as (Prisma.UserCreateInput & {
+		id: string;
+	})[];
+
+	if (postsWithId.length === 0 || usersWithId.length < 2) return;
+
+	const targetPosts = postsWithId.slice(0, Math.min(10, postsWithId.length));
+	const signaled = new Set<string>();
+
+	for (const post of targetPosts) {
+		const reporter = usersWithId.find(
+			(u) => u.id !== post.userId && !signaled.has(`${post.id}:${u.id}`),
+		);
+		if (!reporter) continue;
+
+		const key = `${post.id}:${reporter.id}`;
+		signaled.add(key);
+
+		const reason = randomizer(ALL_REASONS) ?? SignalReason.OTHER;
+		const status = randomizer(ALL_STATUSES) ?? SignalStatus.PENDING;
+
+		await prisma.postSignal.create({
+			data: {
+				postId: post.id,
+				userId: reporter.id,
+				reason,
+				status,
+				details: Math.random() > 0.5 ? faker.lorem.sentence() : null,
+			},
+		});
+	}
+};

--- a/prisma/seeds/users.ts
+++ b/prisma/seeds/users.ts
@@ -48,12 +48,23 @@ export const seedUsers = async (prisma: PrismaClient) => {
 			password: adminPassword,
 			role: "ADMIN",
 			isOnboarded: true,
+			emailVerified: true,
 			userType: UserType.PLAYER,
 			image: UNSPLASH_AVATARS[0],
 			biography: "Administrateur de la plateforme NFE.",
 			localisation: "Paris",
 		},
 	});
+
+	await prisma.account.create({
+		data: {
+			userId: adminUser.id,
+			accountId: adminUser.id,
+			providerId: "credential",
+			password: adminPassword,
+		},
+	});
+
 	users.push(adminUser);
 
 	for (let i = 0; i < 20; i++) {

--- a/prisma/seeds/users.ts
+++ b/prisma/seeds/users.ts
@@ -1,31 +1,93 @@
 import { faker } from "@faker-js/faker";
-import type { Prisma, PrismaClient } from "@prisma/client";
+import {
+	Foot,
+	Position,
+	type Prisma,
+	type PrismaClient,
+	UserType,
+} from "@prisma/client";
+import { randomizer, selectRandomItems } from "../../src/lib/array";
+import { hashPassword } from "../../src/lib/password";
+
+const ALL_POSITIONS = Object.values(Position);
+const ALL_FEET = Object.values(Foot);
+const PLAYER_TYPES = [
+	UserType.PLAYER,
+	UserType.COACH,
+	UserType.RECRUITER,
+	UserType.CLUB,
+];
+
+const UNSPLASH_AVATARS = [
+	"https://images.unsplash.com/photo-1579952363873-27f3bade9f55?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1552667466-07770ae110d0?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1560272564-c83b66b1ad12?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1570498839593-e565b39455fc?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1517466787929-bc90951d0974?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1543326727-cf6c39e8f84c?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1606925797300-0b35e9d1794e?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1504305754058-2f08ccd89a0a?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1459865264687-595d652de67e?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1551958219-acbc595b8b7a?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1574629810360-7efbbe195018?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1431324155629-1a6deb1dec8d?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1540747913346-19e32dc3e97e?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1524786151921-8ec37f68e9c5?w=200&h=200&fit=crop",
+	"https://images.unsplash.com/photo-1610201429291-9e23e3c0b7a7?w=200&h=200&fit=crop",
+];
 
 export const seedUsers = async (prisma: PrismaClient) => {
 	const users: Prisma.UserCreateInput[] = [];
+
+	const adminPassword = await hashPassword("Admin1234!");
+	const adminUser = await prisma.user.create({
+		data: {
+			email: "admin@nfe-foot.com",
+			name: "admin",
+			fullName: "Admin NFE",
+			password: adminPassword,
+			role: "ADMIN",
+			isOnboarded: true,
+			userType: UserType.PLAYER,
+			image: UNSPLASH_AVATARS[0],
+			biography: "Administrateur de la plateforme NFE.",
+			localisation: "Paris",
+		},
+	});
+	users.push(adminUser);
+
 	for (let i = 0; i < 20; i++) {
-		const dbUser = await prisma.user.create({ data: userData() });
+		const dbUser = await prisma.user.create({ data: await userData() });
 		users.push(dbUser);
 	}
 
 	return users;
 };
 
-const userData = (): Prisma.UserCreateInput => {
-	const person = {
-		fullName: faker.person.fullName(),
-	};
+const userData = async (): Promise<Prisma.UserCreateInput> => {
+	const fullName = faker.person.fullName();
+	const userType = randomizer(PLAYER_TYPES) ?? UserType.PLAYER;
+	const isPlayer = userType === UserType.PLAYER;
 
-	const regularUser = {
-		...person,
-		...{
-			email: faker.internet.email({ firstName: person.fullName }),
-			name: faker.internet.username({ firstName: person.fullName }),
-			image: faker.image.avatar(),
-		},
-	};
+	const position = isPlayer
+		? selectRandomItems(ALL_POSITIONS, Math.floor(Math.random() * 3) + 1)
+		: [];
+
+	const foot = isPlayer
+		? selectRandomItems(ALL_FEET, Math.random() > 0.3 ? 1 : 2)
+		: [];
 
 	return {
-		...regularUser,
+		email: faker.internet.email({ firstName: fullName }),
+		name: faker.internet.username({ firstName: fullName }),
+		fullName,
+		image: randomizer(UNSPLASH_AVATARS) ?? UNSPLASH_AVATARS[0],
+		isOnboarded: true,
+		userType,
+		biography: faker.lorem.sentence(),
+		localisation: faker.location.city(),
+		birthday: faker.date.birthdate({ min: 16, max: 40, mode: "age" }),
+		position,
+		foot,
 	} satisfies Prisma.UserCreateInput;
 };

--- a/src/actions/signal.action.ts
+++ b/src/actions/signal.action.ts
@@ -1,0 +1,68 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { getUserRole, getUserSessionId } from "../query/user.query";
+
+async function requireAdmin() {
+	const userId = await getUserSessionId();
+	if (!userId) return null;
+	const role = await getUserRole(userId);
+	if (role !== "ADMIN") return null;
+	return userId;
+}
+
+export async function reviewSignal(signalId: string) {
+	const userId = await requireAdmin();
+	if (!userId) return { error: "Unauthorized" };
+
+	try {
+		await prisma.postSignal.update({
+			where: { id: signalId },
+			data: { status: "REVIEWED" },
+		});
+		revalidatePath("/admin/signals");
+		return { success: true };
+	} catch {
+		return { error: "Failed to review signal" };
+	}
+}
+
+export async function dismissSignal(signalId: string) {
+	const userId = await requireAdmin();
+	if (!userId) return { error: "Unauthorized" };
+
+	try {
+		await prisma.postSignal.update({
+			where: { id: signalId },
+			data: { status: "DISMISSED" },
+		});
+		revalidatePath("/admin/signals");
+		return { success: true };
+	} catch {
+		return { error: "Failed to dismiss signal" };
+	}
+}
+
+export async function rejectSignaledPost(postId: string, signalId: string) {
+	const userId = await requireAdmin();
+	if (!userId) return { error: "Unauthorized" };
+
+	try {
+		await prisma.$transaction([
+			prisma.post.update({
+				where: { id: postId },
+				data: { status: "REJECTED" },
+			}),
+			prisma.postSignal.update({
+				where: { id: signalId },
+				data: { status: "REVIEWED" },
+			}),
+		]);
+		revalidatePath("/admin/signals");
+		revalidatePath(`/post/${postId}`);
+		return { success: true };
+	} catch {
+		return { error: "Failed to reject post" };
+	}
+}

--- a/src/actions/signal.action.ts
+++ b/src/actions/signal.action.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { getUserRole, getUserSessionId } from "../query/user.query";
 
@@ -13,8 +14,9 @@ async function requireAdmin() {
 }
 
 export async function reviewSignal(signalId: string) {
+	const t = await getTranslations("admin.moderation");
 	const userId = await requireAdmin();
-	if (!userId) return { error: "Unauthorized" };
+	if (!userId) return { error: t("unauthorized") };
 
 	try {
 		await prisma.postSignal.update({
@@ -24,13 +26,14 @@ export async function reviewSignal(signalId: string) {
 		revalidatePath("/admin/signals");
 		return { success: true };
 	} catch {
-		return { error: "Failed to review signal" };
+		return { error: t("review-failed") };
 	}
 }
 
 export async function dismissSignal(signalId: string) {
+	const t = await getTranslations("admin.moderation");
 	const userId = await requireAdmin();
-	if (!userId) return { error: "Unauthorized" };
+	if (!userId) return { error: t("unauthorized") };
 
 	try {
 		await prisma.postSignal.update({
@@ -40,13 +43,14 @@ export async function dismissSignal(signalId: string) {
 		revalidatePath("/admin/signals");
 		return { success: true };
 	} catch {
-		return { error: "Failed to dismiss signal" };
+		return { error: t("dismiss-failed") };
 	}
 }
 
 export async function rejectSignaledPost(postId: string, signalId: string) {
+	const t = await getTranslations("admin.moderation");
 	const userId = await requireAdmin();
-	if (!userId) return { error: "Unauthorized" };
+	if (!userId) return { error: t("unauthorized") };
 
 	try {
 		await prisma.$transaction([
@@ -63,6 +67,6 @@ export async function rejectSignaledPost(postId: string, signalId: string) {
 		revalidatePath(`/post/${postId}`);
 		return { success: true };
 	} catch {
-		return { error: "Failed to reject post" };
+		return { error: t("reject-failed") };
 	}
 }

--- a/src/query/signal.query.ts
+++ b/src/query/signal.query.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import type { SignalStatus } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+export const getSignals = async (status?: SignalStatus) => {
+	return prisma.postSignal.findMany({
+		where: status ? { status } : undefined,
+		orderBy: { createdAt: "desc" },
+		include: {
+			post: {
+				select: {
+					id: true,
+					title: true,
+					status: true,
+					medias: {
+						take: 1,
+						select: { url: true },
+					},
+				},
+			},
+			user: {
+				select: {
+					id: true,
+					name: true,
+					image: true,
+				},
+			},
+		},
+	});
+};
+
+export const getPendingSignalCount = async () => {
+	return prisma.postSignal.count({ where: { status: "PENDING" } });
+};
+
+export type SignalWithRelations = Awaited<
+	ReturnType<typeof getSignals>
+>[number];

--- a/src/query/user.query.ts
+++ b/src/query/user.query.ts
@@ -103,6 +103,25 @@ export const getUsers = async ({
 	return users;
 };
 
+export async function getSuggestedUsers(currentUserId: string, limit = 5) {
+	return prisma.user.findMany({
+		where: {
+			isOnboarded: true,
+			id: { not: currentUserId },
+			followeds: { none: { followerId: currentUserId } },
+		},
+		select: {
+			id: true,
+			name: true,
+			image: true,
+			userType: true,
+			position: true,
+		},
+		orderBy: { createdAt: "desc" },
+		take: limit,
+	});
+}
+
 export async function searchUsers(query: string, limit = 10) {
 	if (!query.trim()) return [];
 

--- a/src/query/user.query.ts
+++ b/src/query/user.query.ts
@@ -103,12 +103,17 @@ export const getUsers = async ({
 	return users;
 };
 
-export async function getSuggestedUsers(currentUserId: string, limit = 5) {
+export async function getSuggestedUsers(
+	currentUserId: string | null,
+	limit = 5,
+) {
 	return prisma.user.findMany({
 		where: {
 			isOnboarded: true,
-			id: { not: currentUserId },
-			followeds: { none: { followerId: currentUserId } },
+			...(currentUserId && {
+				id: { not: currentUserId },
+				followeds: { none: { followerId: currentUserId } },
+			}),
 		},
 		select: {
 			id: true,
@@ -116,6 +121,12 @@ export async function getSuggestedUsers(currentUserId: string, limit = 5) {
 			image: true,
 			userType: true,
 			position: true,
+			_count: {
+				select: {
+					followeds: true,
+					posts: { where: { status: "PUBLISHED" } },
+				},
+			},
 		},
 		orderBy: { createdAt: "desc" },
 		take: limit,


### PR DESCRIPTION
## Summary
- Admin **signal moderation** page (`/admin/signals`) with pending count badge, keep/reject/dismiss actions
- User **profile enhancement**: localisation, position, foot fields in edit form and profile display
- **Explore page** now shows suggested users when no query is active; removed unused hashtags/events tabs
- **Post status badges** on `/post/my` (draft, pending, rejected, archived)
- **Follow button** on user suggestions component
- New **`/contact`** static page replacing dead link
- Suggested users surfaced on the home feed
- Richer **seeds**: 20+ users with Unsplash avatars, football videos, follows, likes, comments, favorites, signals
- New UI primitives: `Badge`, `Checkbox` (via `@radix-ui/react-checkbox`)

## Test plan
- [ ] `/admin/signals` shows pending signals and lets admin moderate
- [ ] Profile edit form saves localisation/position/foot
- [ ] Profile display shows bio + localisation + position + foot
- [ ] Explore without query shows suggested users
- [ ] `/post/my` shows status badges for draft/pending/rejected posts
- [ ] `/contact` renders and mailto works
- [ ] `make prisma-reset` succeeds and populates likes/comments/favorites/follows