### PR TITLE
fix(security): remove client-supplied userId from toggleLike and toggleFavorite

### DIFF
--- a/components/feature/post/post-actions.tsx
+++ b/components/feature/post/post-actions.tsx
@@ -56,8 +56,8 @@ export function PostActions({
 
 		(async () => {
 			const [resultLike, resultFavorite] = await Promise.all([
-				hasLiked({ postId, userId }),
-				hasFavorited({ postId, userId }),
+				hasLiked({ postId }),
+				hasFavorited({ postId }),
 			]);
 			setIsLike(resultLike);
 			setIsFavorite(resultFavorite);

--- a/components/feature/post/post-actions.tsx
+++ b/components/feature/post/post-actions.tsx
@@ -78,7 +78,7 @@ export function PostActions({
 		}
 
 		try {
-			const result = await toggleLike({ postId, userId });
+			const result = await toggleLike({ postId });
 			setIsLike(result);
 
 			if (result) {
@@ -99,7 +99,7 @@ export function PostActions({
 		}
 
 		try {
-			const result = await toggleFavorite({ postId, userId });
+			const result = await toggleFavorite({ postId });
 			setIsFavorite(result);
 		} catch (error) {
 			console.error("Error toggling favorite:", error);

--- a/src/actions/favorite.action.ts
+++ b/src/actions/favorite.action.ts
@@ -4,19 +4,11 @@ import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { getUserSessionId } from "@/src/query/user.query";
 
-export const toggleFavorite = async ({
-	postId,
-	userId,
-}: {
-	postId: string;
-	userId?: string | null;
-}) => {
+export const toggleFavorite = async ({ postId }: { postId: string }) => {
 	const t = await getTranslations("actions.favorite");
 
-	if (!userId) {
-		userId = await getUserSessionId();
-		if (!userId) throw new Error(t("user-not-found"));
-	}
+	const userId = await getUserSessionId();
+	if (!userId) throw new Error(t("user-not-found"));
 
 	const favorite = await prisma.favorite.findFirst({
 		where: {

--- a/src/actions/like.action.ts
+++ b/src/actions/like.action.ts
@@ -3,15 +3,13 @@
 import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { createNotification } from "@/src/lib/create-notification";
-import { getUserSession } from "@/src/query/user.query";
+import { getUserSessionId } from "@/src/query/user.query";
 
 export const toggleLike = async ({ postId }: { postId: string }) => {
 	const t = await getTranslations("actions.like");
 
-	const user = await getUserSession();
-	if (!user?.id) throw new Error(t("user-not-found"));
-
-	const userId = user.id;
+	const userId = await getUserSessionId();
+	if (!userId) throw new Error(t("user-not-found"));
 
 	const like = await prisma.like.findFirst({
 		where: {

--- a/src/actions/like.action.ts
+++ b/src/actions/like.action.ts
@@ -5,21 +5,13 @@ import { prisma } from "@/lib/prisma";
 import { createNotification } from "@/src/lib/create-notification";
 import { getUserSession } from "@/src/query/user.query";
 
-export const toggleLike = async ({
-	postId,
-	userId,
-}: {
-	postId: string;
-	userId?: string | null;
-}) => {
+export const toggleLike = async ({ postId }: { postId: string }) => {
 	const t = await getTranslations("actions.like");
 
-	if (!userId) {
-		const user = await getUserSession();
-		if (!user?.id) throw new Error(t("user-not-found"));
+	const user = await getUserSession();
+	if (!user?.id) throw new Error(t("user-not-found"));
 
-		userId = user.id;
-	}
+	const userId = user.id;
 
 	const like = await prisma.like.findFirst({
 		where: {

--- a/src/hooks/use-post-actions.ts
+++ b/src/hooks/use-post-actions.ts
@@ -12,7 +12,7 @@ export const usePostActions = (postId: string, userId?: string) => {
 		if (!userId) return false;
 
 		try {
-			const result = await toggleLike({ postId, userId });
+			const result = await toggleLike({ postId });
 
 			if (result) {
 				likePost(postId);
@@ -31,7 +31,7 @@ export const usePostActions = (postId: string, userId?: string) => {
 		if (!userId) return false;
 
 		try {
-			return await toggleFavorite({ postId, userId });
+			return await toggleFavorite({ postId });
 		} catch (error) {
 			console.error("Error toggling favorite:", error);
 			return false;

--- a/src/hooks/use-post-actions.ts
+++ b/src/hooks/use-post-actions.ts
@@ -5,12 +5,10 @@ import { toggleFavorite } from "@/src/actions/favorite.action";
 import { toggleLike } from "@/src/actions/like.action";
 import { usePostsActions } from "@/src/store/posts.store";
 
-export const usePostActions = (postId: string, userId?: string) => {
+export const usePostActions = (postId: string) => {
 	const { likePost, unlikePost, updatePost } = usePostsActions();
 
 	const handleLike = useCallback(async () => {
-		if (!userId) return false;
-
 		try {
 			const result = await toggleLike({ postId });
 
@@ -25,18 +23,16 @@ export const usePostActions = (postId: string, userId?: string) => {
 			console.error("Error toggling like:", error);
 			return false;
 		}
-	}, [postId, userId, likePost, unlikePost]);
+	}, [postId, likePost, unlikePost]);
 
 	const handleFavorite = useCallback(async () => {
-		if (!userId) return false;
-
 		try {
 			return await toggleFavorite({ postId });
 		} catch (error) {
 			console.error("Error toggling favorite:", error);
 			return false;
 		}
-	}, [postId, userId]);
+	}, [postId]);
 
 	const handleUpdatePost = useCallback(
 		(

--- a/src/query/favorite.query.ts
+++ b/src/query/favorite.query.ts
@@ -25,24 +25,10 @@ export const getFavoritesByUser = async (userId: string) => {
 	return favorites.map((f) => f.post);
 };
 
-export const hasFavorited = async ({
-	userId,
-	postId,
-}: {
-	userId?: string | null;
-	postId: string;
-}) => {
-	if (!userId) {
-		userId = await getUserSessionId();
-		if (!userId) throw new Error("User not found");
-	}
+export const hasFavorited = async ({ postId }: { postId: string }) => {
+	const userId = await getUserSessionId();
+	if (!userId) return false;
 
-	const hasFavorited = await prisma.favorite.count({
-		where: {
-			userId,
-			postId,
-		},
-	});
-
-	return hasFavorited > 0;
+	const count = await prisma.favorite.count({ where: { userId, postId } });
+	return count > 0;
 };

--- a/src/query/like.query.ts
+++ b/src/query/like.query.ts
@@ -1,27 +1,12 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
-import { getUserSession } from "./user.query";
+import { getUserSessionId } from "./user.query";
 
-export const hasLiked = async ({
-	userId,
-	postId,
-}: {
-	userId?: string | null;
-	postId: string;
-}) => {
-	if (!userId) {
-		const user = await getUserSession();
-		if (!user?.id) throw new Error("User not found");
+export const hasLiked = async ({ postId }: { postId: string }) => {
+	const userId = await getUserSessionId();
+	if (!userId) return false;
 
-		userId = user.id;
-	}
-
-	const hasLiked = await prisma.like.count({
-		where: {
-			userId,
-			postId,
-		},
-	});
-	return hasLiked > 0;
+	const count = await prisma.like.count({ where: { userId, postId } });
+	return count > 0;
 };


### PR DESCRIPTION
## Summary
- Removes optional `userId` parameter from `toggleLike` and `toggleFavorite` server actions
- Both actions now always resolve the authenticated user from the server session (`getUserSession` / `getUserSessionId`)
- Updated all callers in `post-actions.tsx` and `use-post-actions.ts` to not pass `userId`

## Security Impact
Prevents any authenticated user from liking or favoriting posts on behalf of other users by supplying an arbitrary `userId` to the server action.

Closes #18

## Also closed
- Closes #15 (already fixed in prior PR — `comment.action.ts` uses session, not client input)
- Closes #16 (already fixed — `change-password.action.ts` passes plaintext to `comparePassword`)

## Test plan
- [ ] Like a post as an authenticated user — like toggles correctly
- [ ] Favorite a post — bookmark toggles correctly
- [ ] Unauthenticated user clicking like → redirected to sign-in