### PR TITLE
fix(i18n): detect browser language from Accept-Language header on first visit

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,17 +1,30 @@
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { getRequestConfig } from "next-intl/server";
 
 export const locales = ["en", "fr"] as const;
 export type Locale = (typeof locales)[number];
 export const defaultLocale: Locale = "fr";
 
+function detectLocaleFromAcceptLanguage(acceptLanguage: string): Locale {
+	for (const part of acceptLanguage.split(",")) {
+		const lang = part.split(";")[0]?.trim().toLowerCase().slice(0, 2);
+		if (lang && locales.includes(lang as Locale)) return lang as Locale;
+	}
+	return defaultLocale;
+}
+
 export default getRequestConfig(async () => {
 	const cookieStore = await cookies();
 	const localeCookie = cookieStore.get("NEXT_LOCALE")?.value;
-	const locale =
-		localeCookie && locales.includes(localeCookie as Locale)
-			? (localeCookie as Locale)
-			: defaultLocale;
+
+	let locale: Locale;
+	if (localeCookie && locales.includes(localeCookie as Locale)) {
+		locale = localeCookie as Locale;
+	} else {
+		const headerStore = await headers();
+		const acceptLanguage = headerStore.get("accept-language") ?? "";
+		locale = detectLocaleFromAcceptLanguage(acceptLanguage);
+	}
 
 	return {
 		locale,

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -6,9 +6,19 @@ export type Locale = (typeof locales)[number];
 export const defaultLocale: Locale = "fr";
 
 function detectLocaleFromAcceptLanguage(acceptLanguage: string): Locale {
-	for (const part of acceptLanguage.split(",")) {
-		const lang = part.split(";")[0]?.trim().toLowerCase().slice(0, 2);
-		if (lang && locales.includes(lang as Locale)) return lang as Locale;
+	const candidates = acceptLanguage
+		.split(",")
+		.map((part) => {
+			const [tag, q] = part.split(";");
+			const lang = tag?.trim().toLowerCase().split("-")[0] ?? "";
+			const quality = q ? Number.parseFloat(q.replace(/.*q=/i, "")) : 1;
+			return { lang, quality: Number.isNaN(quality) ? 1 : quality };
+		})
+		.filter(({ lang }) => lang && lang !== "*")
+		.sort((a, b) => b.quality - a.quality);
+
+	for (const { lang } of candidates) {
+		if (locales.includes(lang as Locale)) return lang as Locale;
 	}
 	return defaultLocale;
 }


### PR DESCRIPTION
## Summary
- Updates `src/i18n/request.ts` to read `Accept-Language` header when no `NEXT_LOCALE` cookie is set
- First-time visitors now see the app in their browser's preferred language (en or fr)
- Explicit language switcher preference (stored in `NEXT_LOCALE` cookie) still takes priority
- Falls back to `fr` (app default) if no supported locale is detected

## Behavior
| Scenario | Before | After |
|----------|--------|-------|
| First visit, browser in English | French | English |
| First visit, browser in French | French | French |
| Cookie set to `en` | English | English |
| Cookie set to `fr` | French | French |
| Cookie set, browser in different lang | Cookie wins | Cookie wins |

Closes #3

## Test plan
- [ ] Visit with no cookie, browser Accept-Language: en → app in English
- [ ] Visit with no cookie, browser Accept-Language: fr → app in French
- [ ] Switch language via switcher → next visit respects cookie