### PR TITLE
fix(production): auth client calling localhost:3500 in production — CORS fix

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 POSTGRES_PORT=3501
 NEXT_PORT=3500
-NEXT_PUBLIC_APP_URL=http://localhost:3500
+NEXT_PUBLIC_APP_URL=https://nfe-foot.com
 POSTGRES_CONTAINER_NAME=nfe-database
 POSTGRES_DB=app
 POSTGRES_USER=app

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -3,7 +3,10 @@
 import { createAuthClient } from "better-auth/react";
 
 export const authClient = createAuthClient({
-	baseURL: process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
+	baseURL:
+		typeof window !== "undefined"
+			? window.location.origin
+			: process.env.NEXT_PUBLIC_APP_URL,
 });
 
 export const { signIn, signOut, signUp, useSession, getSession } = authClient;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -26,7 +26,7 @@ export const auth = betterAuth({
 	},
 	plugins: [nextCookies()],
 	secret: env.NEXTAUTH_SECRET || process.env.BETTER_AUTH_SECRET || "",
-	baseURL: process.env.NEXT_PUBLIC_APP_URL || env.WEBSITE_URL,
+	baseURL: env.WEBSITE_URL || process.env.NEXT_PUBLIC_APP_URL,
 });
 
 export type Session = typeof auth.$Infer.Session;


### PR DESCRIPTION
## 🚨 Production Bug

Auth requests from `https://nfe-foot.com` were targeting `http://localhost:3500` causing CORS failures on sign-in/get-session.

## Root Cause

`NEXT_PUBLIC_APP_URL=http://localhost:3500` was committed in `.env`. Vercel reads this file during builds and bakes the value into the client bundle. The auth client used this as its `baseURL`.

## Fix

### `auth-client.ts`
- Use `window.location.origin` when running in the browser → always targets the correct host regardless of environment
- Falls back to `process.env.NEXT_PUBLIC_APP_URL` for SSR edge cases

### `auth.ts` (server-side)
- Prioritize `WEBSITE_URL` (hardcoded to `https://nfe-foot.com`) over `NEXT_PUBLIC_APP_URL`

### `.env`
- Updated `NEXT_PUBLIC_APP_URL` to `https://nfe-foot.com` — no longer points to localhost

## Immediate Action After Merge

Trigger a Vercel redeploy so the new client bundle is built with the correct URLs.