### PR TITLE
fix: production auth, splash skip & PWA install prompt persistence

### DIFF
--- a/app/splash/page.tsx
+++ b/app/splash/page.tsx
@@ -2,7 +2,6 @@
 
 import { setCookie } from "cookies-next/client";
 import Image from "next/image";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
@@ -66,9 +65,16 @@ export default function SplashPage() {
 					<small className="text-gray-300">
 						{t("new-way-to-experience-football")}
 					</small>
-					<Link href="/">
-						<Button>{t("get-started")}</Button>
-					</Link>
+					<Button
+						onClick={() => {
+							setCookie("seen_splash", "true", {
+								maxAge: 60 * 60 * 24 * 365,
+							});
+							router.push("/");
+						}}
+					>
+						{t("get-started")}
+					</Button>
 				</div>
 			</div>
 		</div>

--- a/app/splash/page.tsx
+++ b/app/splash/page.tsx
@@ -4,7 +4,7 @@ import { setCookie } from "cookies-next/client";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 const SPLASH_IMAGES = [
@@ -13,26 +13,36 @@ const SPLASH_IMAGES = [
 	"https://images.unsplash.com/photo-1517466787929-bc90951d0974?q=80&w=1920",
 ];
 
+const SPLASH_COOKIE_OPTIONS = {
+	maxAge: 60 * 60 * 24 * 365, // 1 year
+	path: "/",
+	sameSite: "lax" as const,
+	secure:
+		typeof window !== "undefined" && window.location.protocol === "https:",
+};
+
 export default function SplashPage() {
 	const [currentImage, setCurrentImage] = useState(0);
 	const router = useRouter();
 	const t = useTranslations("splash");
+
+	const goHome = useCallback(() => {
+		setCookie("seen_splash", "true", SPLASH_COOKIE_OPTIONS);
+		router.push("/");
+	}, [router]);
 
 	useEffect(() => {
 		const interval = setInterval(() => {
 			setCurrentImage((prev) => (prev + 1) % SPLASH_IMAGES.length);
 		}, 3000);
 
-		const timeout = setTimeout(() => {
-			setCookie("seen_splash", "true", { maxAge: 60 * 60 * 24 * 365 }); // 1 year
-			router.push("/");
-		}, 10000);
+		const timeout = setTimeout(goHome, 10000);
 
 		return () => {
 			clearInterval(interval);
 			clearTimeout(timeout);
 		};
-	}, [router]);
+	}, [goHome]);
 
 	return (
 		<div className="fixed inset-0 bg-black">
@@ -65,16 +75,7 @@ export default function SplashPage() {
 					<small className="text-gray-300">
 						{t("new-way-to-experience-football")}
 					</small>
-					<Button
-						onClick={() => {
-							setCookie("seen_splash", "true", {
-								maxAge: 60 * 60 * 24 * 365,
-							});
-							router.push("/");
-						}}
-					>
-						{t("get-started")}
-					</Button>
+					<Button onClick={goHome}>{t("get-started")}</Button>
 				</div>
 			</div>
 		</div>

--- a/components/pwa/install-prompt.tsx
+++ b/components/pwa/install-prompt.tsx
@@ -23,7 +23,7 @@ export function InstallPrompt() {
 	useEffect(() => {
 		if (
 			window.matchMedia("(display-mode: standalone)").matches ||
-			sessionStorage.getItem(DISMISSED_KEY)
+			localStorage.getItem(DISMISSED_KEY)
 		) {
 			return;
 		}
@@ -47,7 +47,7 @@ export function InstallPrompt() {
 			await deferredPrompt.prompt();
 			const { outcome } = await deferredPrompt.userChoice;
 			if (outcome === "dismissed") {
-				sessionStorage.setItem(DISMISSED_KEY, "1");
+				localStorage.setItem(DISMISSED_KEY, "1");
 			}
 		} catch {
 			// prompt may already have been used
@@ -59,7 +59,7 @@ export function InstallPrompt() {
 
 	const handleDismiss = () => {
 		setVisible(false);
-		sessionStorage.setItem(DISMISSED_KEY, "1");
+		localStorage.setItem(DISMISSED_KEY, "1");
 	};
 
 	if (!visible) return null;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,15 +5,26 @@ import { env } from "@/lib/env";
 import { prisma } from "@/lib/prisma";
 import { comparePassword, hashPassword } from "@/src/lib/password";
 
+const secret = env.BETTER_AUTH_SECRET || env.NEXTAUTH_SECRET;
+if (!secret) {
+	throw new Error(
+		"BETTER_AUTH_SECRET is required. Set it in your environment variables.",
+	);
+}
+
 export const auth = betterAuth({
 	database: prismaAdapter(prisma, {
 		provider: "postgresql",
 	}),
 	socialProviders: {
-		google: {
-			clientId: env.GOOGLE_CLIENT_ID || "",
-			clientSecret: env.GOOGLE_CLIENT_SECRET || "",
-		},
+		...(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
+			? {
+					google: {
+						clientId: env.GOOGLE_CLIENT_ID,
+						clientSecret: env.GOOGLE_CLIENT_SECRET,
+					},
+				}
+			: {}),
 	},
 	emailAndPassword: {
 		enabled: true,
@@ -25,8 +36,13 @@ export const auth = betterAuth({
 		},
 	},
 	plugins: [nextCookies()],
-	secret: env.NEXTAUTH_SECRET || process.env.BETTER_AUTH_SECRET || "",
+	secret,
 	baseURL: env.WEBSITE_URL || process.env.NEXT_PUBLIC_APP_URL,
+	trustedOrigins: [
+		env.WEBSITE_URL,
+		process.env.NEXT_PUBLIC_APP_URL,
+		env.BETTER_AUTH_TRUSTED_ORIGIN,
+	].filter(Boolean) as string[],
 });
 
 export type Session = typeof auth.$Infer.Session;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -37,10 +37,10 @@ export const auth = betterAuth({
 	},
 	plugins: [nextCookies()],
 	secret,
-	baseURL: env.WEBSITE_URL || process.env.NEXT_PUBLIC_APP_URL,
+	baseURL: env.WEBSITE_URL || env.NEXT_PUBLIC_APP_URL,
 	trustedOrigins: [
 		env.WEBSITE_URL,
-		process.env.NEXT_PUBLIC_APP_URL,
+		env.NEXT_PUBLIC_APP_URL,
 		env.BETTER_AUTH_TRUSTED_ORIGIN,
 	].filter(Boolean) as string[],
 });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -2,17 +2,19 @@ import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
 export const env = createEnv({
+	emptyStringAsUndefined: true,
 	server: {
 		DATABASE_URL: z
 			.string()
 			.url()
 			.min(1)
 			.regex(/postgres(ql)?:\/\/(.*):(.*)@(.*)\/(.*)/),
-		GOOGLE_CLIENT_ID: z.string().optional(),
-		GOOGLE_CLIENT_SECRET: z.string().optional(),
+		GOOGLE_CLIENT_ID: z.string().min(1).optional(),
+		GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
 		GOOGLE_ANALYTICS_ID: z.string().optional(),
-		BETTER_AUTH_SECRET: z.string().optional(),
-		NEXTAUTH_SECRET: z.string().optional(), // Keep for backward compatibility during migration
+		BETTER_AUTH_SECRET: z.string().min(1).optional(),
+		NEXTAUTH_SECRET: z.string().min(1).optional(),
+		BETTER_AUTH_TRUSTED_ORIGIN: z.string().url().optional(),
 		WEBSITE_URL: z.string().url().min(1).startsWith("https://"),
 
 		// Resend
@@ -34,7 +36,8 @@ export const env = createEnv({
 		GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
 		GOOGLE_ANALYTICS_ID: process.env.GOOGLE_ANALYTICS_ID,
 		BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
-		NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET, // Keep for backward compatibility during migration
+		NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
+		BETTER_AUTH_TRUSTED_ORIGIN: process.env.BETTER_AUTH_TRUSTED_ORIGIN,
 		WEBSITE_URL: process.env.WEBSITE_URL,
 		RESEND_API_KEY: process.env.RESEND_API_KEY,
 		CLOUDINARY_CLOUD_NAME: process.env.CLOUDINARY_CLOUD_NAME,


### PR DESCRIPTION
## Summary

Three production bugs fixed in one PR:

### 1. Production auth (Google + credentials)
- `auth.ts`: throw early if `BETTER_AUTH_SECRET` is missing instead of running with `secret = ""` (silent failure)
- Add `trustedOrigins` from `WEBSITE_URL` + optional `BETTER_AUTH_TRUSTED_ORIGIN` to handle alternate Vercel preview domains
- Google provider now only registers when both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set (avoids passing empty strings to better-auth)
- `env.ts`: `emptyStringAsUndefined: true` + `.min(1)` on secret/OAuth fields so empty `.env` template values don't pass validation
- New optional env: `BETTER_AUTH_TRUSTED_ORIGIN`

### 2. Splash screen redirect loop
- The "Commencer" button was a `<Link href="/">` — clicking it unmounted the splash component, the `useEffect` cleanup fired `clearTimeout` before `setCookie("seen_splash", ...)` could run, and the home page (`getHasSeenSplash() === false`) redirected back to `/splash`
- Fix: button now sets the cookie synchronously, then navigates via `router.push("/")`

### 3. PWA install prompt re-appears every page
- `sessionStorage` is cleared when the tab closes — and effectively per-tab, so users got the prompt again on every new visit even after dismissing it
- Switch to `localStorage` so the dismiss flag persists

## Test plan

- [ ] Production: Google sign-in works
- [ ] Production: email/password sign-in works
- [ ] Splash: click "Commencer" → lands on home, no loop back to /splash
- [ ] Splash cookie persists across reloads
- [ ] PWA prompt: click X → reload page → does not reappear
- [ ] PWA prompt: click X → close tab → reopen → does not reappear