### PR TITLE
fix(i18n): translate football positions in edit profile form

### DIFF
--- a/app/(home)/(private)/profile/edit-user/user-form.tsx
+++ b/app/(home)/(private)/profile/edit-user/user-form.tsx
@@ -27,12 +27,6 @@ import { userSchema } from "./user.schema";
 
 const ALL_POSITIONS = Object.values(Position);
 
-const toDisplayLabel = (value: string) =>
-	value
-		.replace(/_/g, " ")
-		.toLowerCase()
-		.replace(/\b\w/g, (c) => c.toUpperCase());
-
 const getFootValue = (foot: Foot[]): string => {
 	if (foot.includes(Foot.LEFT) && foot.includes(Foot.RIGHT)) return "BOTH";
 	if (foot.includes(Foot.LEFT)) return "LEFT";
@@ -182,7 +176,7 @@ export const UserForm = ({ userId }: { userId: string }) => {
 								htmlFor={`pos-${pos}`}
 								className="font-normal cursor-pointer"
 							>
-								{toDisplayLabel(pos)}
+								{t(pos)}
 							</Label>
 						</div>
 					))}

--- a/messages/en.json
+++ b/messages/en.json
@@ -427,7 +427,18 @@
 			"change-password": "Change Password",
 			"foot-left": "Left",
 			"foot-right": "Right",
-			"foot-both": "Both"
+			"foot-both": "Both",
+			"GOALKEEPER": "Goalkeeper",
+			"CENTRE_BACK": "Centre Back",
+			"RIGHT_BACK": "Right Back",
+			"LEFT_BACK": "Left Back",
+			"DEFENSIVE_MIDFIELDER": "Defensive Midfielder",
+			"CENTRE_MIDFIELDER": "Centre Midfielder",
+			"ATTACKING_MIDFIELDER": "Attacking Midfielder",
+			"RIGHT_WINGER": "Right Winger",
+			"LEFT_WINGER": "Left Winger",
+			"CENTRE_FORWARD": "Centre Forward",
+			"STRIKER": "Striker"
 		}
 	},
 	"auth": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -427,7 +427,18 @@
 			"change-password": "Changer le mot de passe",
 			"foot-left": "Gauche",
 			"foot-right": "Droite",
-			"foot-both": "Les deux"
+			"foot-both": "Les deux",
+			"GOALKEEPER": "Gardien de but",
+			"CENTRE_BACK": "Défenseur central",
+			"RIGHT_BACK": "Arrière droit",
+			"LEFT_BACK": "Arrière gauche",
+			"DEFENSIVE_MIDFIELDER": "Milieu défensif",
+			"CENTRE_MIDFIELDER": "Milieu central",
+			"ATTACKING_MIDFIELDER": "Milieu offensif",
+			"RIGHT_WINGER": "Ailier droit",
+			"LEFT_WINGER": "Ailier gauche",
+			"CENTRE_FORWARD": "Avant-centre",
+			"STRIKER": "Attaquant"
 		}
 	},
 	"auth": {


### PR DESCRIPTION
## Summary
- Football positions on the edit profile form (Goalkeeper, Centre Back, Right Back, etc.) were displayed in English even when the locale was French
- The previous `toDisplayLabel` helper just reformatted the Prisma enum value into Title Case English, bypassing i18n entirely
- Added FR/EN translations for all 11 `Position` enum values in `profile.edit-user` namespace and replaced `toDisplayLabel(pos)` with `t(pos)` so labels follow the active locale

## Test plan
- [ ] Open `/profile/edit-user` in French → all 11 positions show in French (e.g. "Gardien de but", "Défenseur central")
- [ ] Switch to English → labels switch to English
- [ ] Saving and toggling positions still works (no logic change)