### PR TITLE
fix(upload): thumbnail optional + increase body size limit to 50mb

### DIFF
--- a/app/(home)/(private)/post/new/save-post.action.ts
+++ b/app/(home)/(private)/post/new/save-post.action.ts
@@ -43,7 +43,7 @@ export const savePost = async (post: PostData) => {
 		});
 	}
 
-	const [imageUrl, videoUrl] = await Promise.all([
+	const [_imageUrl, videoUrl] = await Promise.all([
 		saveMedia({
 			mediaFile: post.image,
 			postId: newPost.id,
@@ -56,8 +56,8 @@ export const savePost = async (post: PostData) => {
 		}),
 	]);
 
-	if (!imageUrl || !videoUrl) {
-		throw new Error("Échec du téléchargement du fichier média");
+	if (!videoUrl) {
+		throw new Error("Échec du téléchargement de la vidéo");
 	}
 
 	return newPost;

--- a/next.config.ts
+++ b/next.config.ts
@@ -124,7 +124,7 @@ const nextConfig: NextConfig = {
 	},
 	experimental: {
 		serverActions: {
-			bodySizeLimit: "10mb",
+			bodySizeLimit: "50mb",
 		},
 	},
 };


### PR DESCRIPTION
## Summary
- **Bug**: `save-post.action.ts` required BOTH video AND thumbnail to be uploaded successfully (`if (!imageUrl || !videoUrl)`), but the thumbnail is optional in the UI — any upload without a thumbnail would throw and trigger the \"Server Components render\" error overlay
- **Fix**: Changed condition to `if (!videoUrl)` — only the video is required
- **Body size limit**: Increased server action body size limit from 10mb → 50mb to handle typical mobile video files (base64 encoding adds ~33% overhead)

## Root cause
`saveMedia()` returns `null` when no file is provided. Since `post.image` (thumbnail) is optional, `imageUrl` was always `null` → `!imageUrl` was always `true` → every upload failed with an unhandled server error.