### PR TITLE
feat(upload): direct client→Cloudinary upload with progress bar

### DIFF
--- a/app/(home)/(private)/post/new/get-upload-signature.action.ts
+++ b/app/(home)/(private)/post/new/get-upload-signature.action.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { v2 as cloudinary } from "cloudinary";
+import { env } from "@/lib/env";
+
+cloudinary.config({
+	cloud_name: env.CLOUDINARY_CLOUD_NAME || "",
+	api_key: env.CLOUDINARY_API_KEY || "",
+	api_secret: env.CLOUDINARY_API_SECRET || "",
+	secure: true,
+});
+
+export async function getUploadSignature(resourceType: "image" | "video") {
+	const timestamp = Math.round(Date.now() / 1000);
+	const folder = env.CLOUDINARY_FOLDER || "uploads";
+	const paramsToSign = { timestamp, folder };
+
+	const signature = cloudinary.utils.api_sign_request(
+		paramsToSign,
+		env.CLOUDINARY_API_SECRET || "",
+	);
+
+	return {
+		signature,
+		timestamp,
+		cloudName: env.CLOUDINARY_CLOUD_NAME || "",
+		apiKey: env.CLOUDINARY_API_KEY || "",
+		folder,
+		resourceType,
+	};
+}

--- a/app/(home)/(private)/post/new/make-post-form.tsx
+++ b/app/(home)/(private)/post/new/make-post-form.tsx
@@ -11,23 +11,27 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import type { PostData } from "./post.schema";
+import { uploadToCloudinaryDirect } from "@/src/lib/cloudinary-client-upload";
+import { getUploadSignature } from "./get-upload-signature.action";
 import { savePost } from "./save-post.action";
 
 export default function MakePostForm() {
 	const t = useTranslations("posts.new");
 	const router = useRouter();
+
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [selectedVideo, setSelectedVideo] = useState<File | null>(null);
 	const [selectedThumbnail, setSelectedThumbnail] = useState<File | null>(null);
 	const [title, setTitle] = useState("");
 	const [description, setDescription] = useState("");
+	const [uploadProgress, setUploadProgress] = useState(0);
 
 	const handleSavePost = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		setIsLoading(true);
 		setError(null);
+		setUploadProgress(0);
 
 		if (!selectedVideo) {
 			setError(t("video-required"));
@@ -35,25 +39,67 @@ export default function MakePostForm() {
 			return;
 		}
 
-		const data = {
-			title,
-			description,
-			image: selectedThumbnail,
-			video: selectedVideo,
-		} as PostData;
+		try {
+			const [videoSig, imageSig] = await Promise.all([
+				getUploadSignature("video"),
+				selectedThumbnail ? getUploadSignature("image") : Promise.resolve(null),
+			]);
 
-		savePost(data)
-			.then((post: Post) => {
-				toast.success(t("post-created-successfully"));
-				router.push(`/post/${post.id}`);
-			})
-			.catch((error) => {
-				setError(error.message);
-				toast.error(error.message);
-			})
-			.finally(() => {
-				setIsLoading(false);
+			const videoResult = await uploadToCloudinaryDirect(
+				selectedVideo,
+				videoSig,
+				(pct) =>
+					setUploadProgress(Math.round(pct * (selectedThumbnail ? 0.85 : 1))),
+			);
+
+			let imageResult = null;
+			if (selectedThumbnail && imageSig) {
+				imageResult = await uploadToCloudinaryDirect(
+					selectedThumbnail,
+					imageSig,
+					(pct) => setUploadProgress(85 + Math.round(pct * 0.15)),
+				);
+			}
+
+			setUploadProgress(100);
+
+			const post: Post = await savePost({
+				title,
+				description,
+				videoPublicId: videoResult.public_id,
+				videoUrl: videoResult.secure_url,
+				videoMimeType: selectedVideo.type,
+				videoMetadata: {
+					width: videoResult.width,
+					height: videoResult.height,
+					format: videoResult.format,
+					resource_type: videoResult.resource_type,
+					public_id: videoResult.public_id,
+					duration: videoResult.duration,
+				},
+				imagePublicId: imageResult?.public_id ?? null,
+				imageUrl: imageResult?.secure_url ?? null,
+				imageMimeType: selectedThumbnail?.type ?? null,
+				imageMetadata: imageResult
+					? {
+							width: imageResult.width,
+							height: imageResult.height,
+							format: imageResult.format,
+							resource_type: imageResult.resource_type,
+							public_id: imageResult.public_id,
+						}
+					: null,
 			});
+
+			toast.success(t("post-created-successfully"));
+			router.push(`/post/${post.id}`);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : t("video-required");
+			setError(message);
+			toast.error(message);
+		} finally {
+			setIsLoading(false);
+		}
 	};
 
 	const isFormValid = title.trim() && description.trim() && selectedVideo;
@@ -90,7 +136,7 @@ export default function MakePostForm() {
 					onVideoChange={setSelectedVideo}
 					onThumbnailChange={setSelectedThumbnail}
 					isUploading={isLoading}
-					uploadProgress={isLoading ? 50 : 0}
+					uploadProgress={uploadProgress}
 				/>
 
 				<Button
@@ -102,7 +148,7 @@ export default function MakePostForm() {
 					{isLoading ? (
 						<>
 							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-							{t("publishing")}
+							{uploadProgress < 100 ? `${uploadProgress}%` : t("publishing")}
 						</>
 					) : (
 						t("submit")

--- a/app/(home)/(private)/post/new/post.schema.ts
+++ b/app/(home)/(private)/post/new/post.schema.ts
@@ -1,10 +1,16 @@
 import { z } from "zod";
 
 export const postSchema = z.object({
-	title: z.string(),
-	description: z.string(),
-	image: z.instanceof(File).optional().nullable(),
-	video: z.instanceof(File).optional().nullable(),
+	title: z.string().min(1),
+	description: z.string().min(1),
+	videoPublicId: z.string().min(1),
+	videoUrl: z.string().url(),
+	videoMimeType: z.string(),
+	videoMetadata: z.record(z.string(), z.unknown()).optional(),
+	imagePublicId: z.string().optional().nullable(),
+	imageUrl: z.string().url().optional().nullable(),
+	imageMimeType: z.string().optional().nullable(),
+	imageMetadata: z.record(z.string(), z.unknown()).optional().nullable(),
 });
 
 export type PostData = z.infer<typeof postSchema>;

--- a/app/(home)/(private)/post/new/save-post.action.ts
+++ b/app/(home)/(private)/post/new/save-post.action.ts
@@ -1,7 +1,6 @@
 "use server";
 
-import { MediaType, PostStatus, PostType } from "@prisma/client";
-import { uploadToCloudinary } from "@/lib/cloudinary";
+import { MediaType, PostStatus, PostType, type Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/src/lib/auth-server";
 import { type PostData, postSchema } from "./post.schema";
@@ -14,7 +13,6 @@ export const savePost = async (post: PostData) => {
 	}
 
 	const result = postSchema.safeParse(post);
-
 	if (!result.success) {
 		throw new Error(
 			`Validation error: ${result.error.issues[0]?.message ?? "Unknown error"}`,
@@ -24,10 +22,7 @@ export const savePost = async (post: PostData) => {
 	const slug = post.title.toLowerCase().replace(/ /g, "-");
 
 	let newPost = await prisma.post.findFirst({
-		where: {
-			slug: slug,
-			userId: session.user.id,
-		},
+		where: { slug, userId: session.user.id },
 	});
 
 	if (!newPost) {
@@ -36,71 +31,38 @@ export const savePost = async (post: PostData) => {
 				title: post.title,
 				description: post.description,
 				userId: session.user.id,
-				slug: slug,
+				slug,
 				type: PostType.video,
 				status: PostStatus.PUBLISHED,
 			},
 		});
 	}
 
-	const [_imageUrl, videoUrl] = await Promise.all([
-		saveMedia({
-			mediaFile: post.image,
-			postId: newPost.id,
-			type: MediaType.landingImage,
-		}),
-		saveMedia({
-			mediaFile: post.video,
-			postId: newPost.id,
-			type: MediaType.mainVideo,
-		}),
-	]);
-
-	if (!videoUrl) {
-		throw new Error("Échec du téléchargement de la vidéo");
-	}
-
-	return newPost;
-};
-
-const saveMedia = async ({
-	mediaFile,
-	postId,
-	type,
-}: {
-	mediaFile?: File | null | undefined;
-	postId: string;
-	type: MediaType;
-}) => {
-	if (!mediaFile) return null;
-
-	const upload = await uploadToCloudinary(mediaFile, {
-		folder: "posts",
-		transformation: [{ width: 1200, crop: "limit" }],
-	});
-
-	if (!upload) {
-		throw new Error("Échec du téléchargement du fichier média");
-	}
-
-	const media = await prisma.media.create({
+	await prisma.media.create({
 		data: {
-			url: upload.secure_url,
-			postId: postId,
-			mimetype: mediaFile.type,
-			type: type,
-			filename: upload.public_id,
-			label: mediaFile.name,
-			metadata: {
-				width: upload.width,
-				height: upload.height,
-				format: upload.format,
-				resource_type: upload.resource_type,
-				public_id: upload.public_id,
-				duration: upload.duration,
-			},
+			url: post.videoUrl,
+			postId: newPost.id,
+			mimetype: post.videoMimeType,
+			type: MediaType.mainVideo,
+			filename: post.videoPublicId,
+			label: post.videoPublicId,
+			metadata: (post.videoMetadata ?? {}) as Prisma.InputJsonValue,
 		},
 	});
 
-	return media;
+	if (post.imagePublicId && post.imageUrl) {
+		await prisma.media.create({
+			data: {
+				url: post.imageUrl,
+				postId: newPost.id,
+				mimetype: post.imageMimeType ?? "image/jpeg",
+				type: MediaType.landingImage,
+				filename: post.imagePublicId,
+				label: post.imagePublicId,
+				metadata: (post.imageMetadata ?? {}) as Prisma.InputJsonValue,
+			},
+		});
+	}
+
+	return newPost;
 };

--- a/src/lib/cloudinary-client-upload.ts
+++ b/src/lib/cloudinary-client-upload.ts
@@ -1,0 +1,62 @@
+export interface CloudinaryUploadSignature {
+	signature: string;
+	timestamp: number;
+	cloudName: string;
+	apiKey: string;
+	folder: string;
+	resourceType: "image" | "video";
+}
+
+export interface CloudinaryUploadResult {
+	public_id: string;
+	secure_url: string;
+	url: string;
+	resource_type: string;
+	format: string;
+	width?: number;
+	height?: number;
+	duration?: number;
+}
+
+export function uploadToCloudinaryDirect(
+	file: File,
+	sig: CloudinaryUploadSignature,
+	onProgress?: (percent: number) => void,
+): Promise<CloudinaryUploadResult> {
+	return new Promise((resolve, reject) => {
+		const formData = new FormData();
+		formData.append("file", file);
+		formData.append("api_key", sig.apiKey);
+		formData.append("timestamp", String(sig.timestamp));
+		formData.append("signature", sig.signature);
+		formData.append("folder", sig.folder);
+
+		const xhr = new XMLHttpRequest();
+
+		xhr.upload.addEventListener("progress", (e) => {
+			if (e.lengthComputable) {
+				onProgress?.(Math.round((e.loaded / e.total) * 100));
+			}
+		});
+
+		xhr.addEventListener("load", () => {
+			if (xhr.status === 200) {
+				resolve(JSON.parse(xhr.responseText) as CloudinaryUploadResult);
+			} else {
+				const body = JSON.parse(xhr.responseText) as {
+					error?: { message: string };
+				};
+				reject(new Error(body.error?.message ?? "Upload failed"));
+			}
+		});
+
+		xhr.addEventListener("error", () => reject(new Error("Upload failed")));
+		xhr.addEventListener("abort", () => reject(new Error("Upload aborted")));
+
+		xhr.open(
+			"POST",
+			`https://api.cloudinary.com/v1_1/${sig.cloudName}/${sig.resourceType}/upload`,
+		);
+		xhr.send(formData);
+	});
+}


### PR DESCRIPTION
## Summary
- Videos are now uploaded **directly from the browser to Cloudinary** via signed XHR — they no longer pass through Vercel serverless functions
- Eliminates the Vercel 4.5MB body size limit for uploads entirely
- Real upload progress bar (0–100%) on the submit button during upload
- Server Action now only handles a lightweight signature generation + DB write, no file data

## Architecture change
**Before**: `Browser → Vercel Server Action (file as base64) → Cloudinary`
**After**: `Browser → Cloudinary (XHR, direct) → Vercel Server Action (public_id only) → DB`

## New files
- `get-upload-signature.action.ts` — Server Action that generates a Cloudinary upload signature (never exposes API secret)
- `src/lib/cloudinary-client-upload.ts` — XHR upload utility with progress callback

## Modified files
- `post.schema.ts` — accepts `public_id` / URL strings instead of File objects
- `save-post.action.ts` — DB-only, no Cloudinary upload
- `make-post-form.tsx` — orchestrates signature fetch → direct upload → savePost

## Test plan
- [ ] Upload a large video (>50MB) on mobile — should work without error
- [ ] Progress bar shows correct percentage during upload
- [ ] Thumbnail upload (optional) still works
- [ ] Post is created and navigates to post page on success