### PR TITLE
fix(i18n): translate hardcoded strings on messages page

### DIFF
--- a/app/(home)/(private)/messages/components/message-header.tsx
+++ b/app/(home)/(private)/messages/components/message-header.tsx
@@ -1,18 +1,21 @@
 import { Search } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { Input } from "@/components/ui/input";
 
-export function MessageHeader() {
+export async function MessageHeader() {
+	const t = await getTranslations("messages-page");
+
 	return (
 		<header className="sticky top-0 z-40 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
 			<div className="container p-4">
 				<div className="flex justify-between items-center mb-4">
-					<h1 className="text-xl font-semibold">Messages</h1>
+					<h1 className="text-xl font-semibold">{t("title")}</h1>
 				</div>
 				<div className="relative mb-4">
 					<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 					<Input
 						type="search"
-						placeholder="Search here"
+						placeholder={t("search-placeholder")}
 						className="pl-9 bg-muted border-none"
 					/>
 				</div>

--- a/app/(home)/(private)/messages/components/search-users-dialog.tsx
+++ b/app/(home)/(private)/messages/components/search-users-dialog.tsx
@@ -3,6 +3,7 @@
 import { Plus, Search } from "lucide-react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,6 +19,7 @@ import { searchUsers } from "../actions/search-users.action";
 import type { MessageUser } from "../types";
 
 export function SearchUsersDialog() {
+	const t = useTranslations("messages-page");
 	const [searchQuery, setSearchQuery] = useState("");
 	const [isOpen, setIsOpen] = useState(false);
 	const [searchResults, setSearchResults] = useState<MessageUser[]>([]);
@@ -32,7 +34,7 @@ export function SearchUsersDialog() {
 			const results = await searchUsers(query);
 			setSearchResults(results);
 		} catch (error) {
-			console.error("Erreur lors de la recherche:", error);
+			console.error("Search error:", error);
 			setSearchResults([]);
 		} finally {
 			setIsSearching(false);
@@ -56,12 +58,12 @@ export function SearchUsersDialog() {
 			</DialogTrigger>
 			<DialogContent className="sm:max-w-[425px]">
 				<DialogHeader>
-					<DialogTitle>Rechercher des utilisateurs</DialogTitle>
+					<DialogTitle>{t("search-dialog.title")}</DialogTitle>
 				</DialogHeader>
 				<div className="relative">
 					<Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
 					<Input
-						placeholder="Rechercher un utilisateur..."
+						placeholder={t("search-dialog.placeholder")}
 						className="pl-8"
 						value={searchQuery}
 						onChange={(e) => handleSearch(e.target.value)}
@@ -70,7 +72,9 @@ export function SearchUsersDialog() {
 				<ScrollArea className="h-[300px] mt-4">
 					{isSearching ? (
 						<div className="flex items-center justify-center h-full">
-							<p className="text-muted-foreground">Recherche en cours...</p>
+							<p className="text-muted-foreground">
+								{t("search-dialog.searching")}
+							</p>
 						</div>
 					) : searchResults.length > 0 ? (
 						<div className="space-y-2">
@@ -96,7 +100,9 @@ export function SearchUsersDialog() {
 						</div>
 					) : searchQuery ? (
 						<div className="flex items-center justify-center h-full">
-							<p className="text-muted-foreground">Aucun utilisateur trouvé</p>
+							<p className="text-muted-foreground">
+								{t("search-dialog.no-results")}
+							</p>
 						</div>
 					) : null}
 				</ScrollArea>

--- a/app/(home)/(private)/messages/components/user-list.tsx
+++ b/app/(home)/(private)/messages/components/user-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import type { MessageUser } from "../types";
@@ -11,12 +12,16 @@ interface UserListProps {
 }
 
 export function UserList({ users }: UserListProps) {
+	const t = useTranslations("messages-page");
+
 	return (
 		<ScrollArea className="w-full whitespace-nowrap mb-6">
 			<div className="flex gap-4">
 				<div className="flex flex-col items-center gap-1">
 					<SearchUsersDialog />
-					<span className="text-xs text-muted-foreground">New</span>
+					<span className="text-xs text-muted-foreground">
+						{t("new-conversation")}
+					</span>
 				</div>
 				{users.map((user) => (
 					<div key={user.id} className="flex flex-col items-center gap-1">

--- a/app/(home)/(private)/messages/page.tsx
+++ b/app/(home)/(private)/messages/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { getSession } from "@/src/lib/auth-server";
 import { MessageHeader } from "./components/message-header";
@@ -8,6 +9,7 @@ import { getMessagesGroupedByUser, getUsersWithMessages } from "./queries";
 export default async function MessagesPage() {
 	const session = await getSession();
 	const userId = session?.user?.id;
+	const t = await getTranslations("messages-page");
 
 	const [users, groupedMessages] = userId
 		? await Promise.all([
@@ -16,7 +18,6 @@ export default async function MessagesPage() {
 			])
 		: [[], {}];
 
-	// Transformer les messages groupés en un tableau plat
 	const messages = Object.values(groupedMessages).flat();
 
 	return (
@@ -32,13 +33,13 @@ export default async function MessagesPage() {
 							value="messages"
 							className="data-[state=active]:bg-background rounded-sm"
 						>
-							Messages
+							{t("tab-messages")}
 						</TabsTrigger>
 						<TabsTrigger
 							value="favorites"
 							className="data-[state=active]:bg-background rounded-sm"
 						>
-							Favorites
+							{t("tab-favorites")}
 						</TabsTrigger>
 					</TabsList>
 				</Tabs>

--- a/messages/en.json
+++ b/messages/en.json
@@ -545,6 +545,19 @@
 		"description": "Have a question or feedback? Reach out to us at the address below.",
 		"social-title": "Follow us"
 	},
+	"messages-page": {
+		"title": "Messages",
+		"search-placeholder": "Search here",
+		"new-conversation": "New",
+		"tab-messages": "Messages",
+		"tab-favorites": "Favorites",
+		"search-dialog": {
+			"title": "Search users",
+			"placeholder": "Search a user...",
+			"searching": "Searching...",
+			"no-results": "No users found"
+		}
+	},
 	"pwa": {
 		"install": {
 			"title": "Install the app",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -545,6 +545,19 @@
 		"description": "Une question ou un retour ? Contactez-nous à l'adresse ci-dessous.",
 		"social-title": "Suivez-nous"
 	},
+	"messages-page": {
+		"title": "Messages",
+		"search-placeholder": "Rechercher ici",
+		"new-conversation": "Nouveau",
+		"tab-messages": "Messages",
+		"tab-favorites": "Favoris",
+		"search-dialog": {
+			"title": "Rechercher des utilisateurs",
+			"placeholder": "Rechercher un utilisateur...",
+			"searching": "Recherche en cours...",
+			"no-results": "Aucun utilisateur trouvé"
+		}
+	},
 	"pwa": {
 		"install": {
 			"title": "Installer l'app",


### PR DESCRIPTION
## Summary

The messages page had hardcoded strings (some in French only) that bypassed the i18n system. This PR adds a `messages-page` translation namespace and wires it through all 4 components on the route.

## Changes

- **New translations** in `messages/en.json` and `messages/fr.json` under `messages-page`:
  - `title`, `search-placeholder`, `new-conversation`, `tab-messages`, `tab-favorites`
  - `search-dialog.{title,placeholder,searching,no-results}`
- **`message-header.tsx`** — page title and search input placeholder now translated (made async to use `getTranslations`)
- **`user-list.tsx`** — "New" label under the new conversation button now translated
- **`search-users-dialog.tsx`** — 4 French-hardcoded strings (dialog title, input placeholder, "Recherche en cours...", "Aucun utilisateur trouvé") now translated
- **`messages/page.tsx`** — "Messages" and "Favorites" tab labels now translated

## Test plan
- [ ] Visit `/messages` with `NEXT_LOCALE=en` → all strings show in English
- [ ] Visit `/messages` with `NEXT_LOCALE=fr` → all strings show in French
- [ ] Open the "+" button on the user list → search dialog title, placeholder, and empty/loading states display correctly in both locales