### PR TITLE
fix(db): restore missing NotificationType migration — fixes /notifications crash

### DIFF
--- a/prisma/migrations/20260509000000_add_notification_type/migration.sql
+++ b/prisma/migrations/20260509000000_add_notification_type/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('LIKE', 'COMMENT', 'FOLLOW', 'MESSAGE');
+
+-- AlterTable
+ALTER TABLE "Notification" ADD COLUMN "type" "NotificationType" NOT NULL DEFAULT 'COMMENT';


### PR DESCRIPTION
## Root Cause

The migration `20260412140633_add_notification_type` (which added the `NotificationType` enum and `type` column to the `Notification` table) was applied to the local dev DB but **deleted from the repo** before being merged. As a result, `prisma migrate deploy` on Vercel never applied it, leaving the production PostgreSQL database without the `type` column.

At runtime, `prisma.notification.findMany()` generates:
```sql
SELECT "id", "userId", "type", "content", ... FROM "Notification" WHERE "userId" = $1
```

PostgreSQL returns: `ERROR: column "type" does not exist` → Next.js server component boundary catches it and shows the generic production error page.

## Fix

Recreates the migration as `20260509000000_add_notification_type`:

```sql
CREATE TYPE "NotificationType" AS ENUM ('LIKE', 'COMMENT', 'FOLLOW', 'MESSAGE');
ALTER TABLE "Notification" ADD COLUMN "type" "NotificationType" NOT NULL DEFAULT 'COMMENT';
```

`vercel-build` runs `prisma migrate deploy` which will apply this migration to production on next deploy.

## Verification

- `prisma migrate status` → "Database schema is up to date" after marking applied on local dev
- `bun run build` → succeeds
- Local dev: `/notifications` renders correctly