### PR TITLE
fix(i18n): add missing feature.search translations on explore page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -501,6 +501,17 @@
 				"close": "Close",
 				"connect": "Connect"
 			}
+		},
+		"search": {
+			"user-types": {
+				"PLAYER": "Player",
+				"COACH": "Coach",
+				"RECRUITER": "Recruiter",
+				"CLUB": "Club"
+			},
+			"followers": "followers",
+			"posts": "posts",
+			"view-profile": "View profile"
 		}
 	},
 	"actions": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -501,6 +501,17 @@
 				"close": "Fermer",
 				"connect": "Se connecter"
 			}
+		},
+		"search": {
+			"user-types": {
+				"PLAYER": "Joueur",
+				"COACH": "Entraîneur",
+				"RECRUITER": "Recruteur",
+				"CLUB": "Club"
+			},
+			"followers": "abonnés",
+			"posts": "posts",
+			"view-profile": "Voir le profil"
 		}
 	},
 	"actions": {


### PR DESCRIPTION
## Summary
- Add the missing `feature.search` namespace in `messages/fr.json` and `messages/en.json`
- Provide translations for `user-types` (`PLAYER`, `COACH`, `RECRUITER`, `CLUB`), `followers`, `posts`, and `view-profile`
- Suggested user cards on `/explore` now render translated labels instead of raw keys (`feature.search.user-types.coach`, `feature.search.followers`, …)

## Test plan
- [ ] Visit `/explore` (logged out and logged in) in `fr` and `en`, confirm badges show "Joueur / Entraîneur / Recruteur / Club" (resp. "Player / Coach / Recruiter / Club")
- [ ] Confirm `followers` and `posts` counters render translated labels under each card
- [ ] Logged-out: confirm `Voir le profil` / `View profile` button label