### PR TITLE
fix(post): remove duplicate comment form on detail page and improve video fallback

### DIFF
--- a/app/(home)/(public)/post/[id]/post-card.tsx
+++ b/app/(home)/(public)/post/[id]/post-card.tsx
@@ -21,7 +21,10 @@ export const PostCard = ({ post }: { post: PostWithUserAndMedias }) => {
 
 	return (
 		<article className="flex-grow mx-auto p-4 px-0 space-y-4">
-			<PostDetails post={post}>
+			<PostDetails
+				post={post}
+				onCommentClick={() => commentFormRef.current?.focus()}
+			>
 				<PostFormComment
 					ref={commentFormRef}
 					postId={post.id}

--- a/components/feature/post/post-actions.tsx
+++ b/components/feature/post/post-actions.tsx
@@ -26,6 +26,7 @@ interface PostActionsProps {
 	comments?: number;
 	postId: string;
 	title?: string;
+	onCommentClick?: () => void;
 }
 
 export function PostActions({
@@ -33,6 +34,7 @@ export function PostActions({
 	comments: initialComments = 0,
 	postId,
 	title,
+	onCommentClick,
 }: PostActionsProps) {
 	const { data: session, isPending } = useSession();
 	const userId = session?.user?.id;
@@ -112,7 +114,11 @@ export function PostActions({
 			redirectToSignIn();
 			return;
 		}
-		setShowCommentForm(!showCommentForm);
+		if (onCommentClick) {
+			onCommentClick();
+		} else {
+			setShowCommentForm(!showCommentForm);
+		}
 	};
 
 	const updateCommentCount = () => {

--- a/components/feature/post/post-content.tsx
+++ b/components/feature/post/post-content.tsx
@@ -64,15 +64,15 @@ export function PostContent({ post }: PostContentProps) {
 		}
 	};
 
-	const getVideoUrl = () => {
+	const transformedVideoUrl = (() => {
 		if (
 			video.url.includes("cloudinary.com") &&
 			video.url.includes("/upload/")
 		) {
-			return video.url.replace("/upload/", "/upload/f_mp4,vc_auto/");
+			return video.url.replace("/upload/", "/upload/f_mp4/");
 		}
-		return video.url;
-	};
+		return null;
+	})();
 
 	return (
 		<div className="relative aspect-video w-full overflow-hidden">
@@ -94,7 +94,10 @@ export function PostContent({ post }: PostContentProps) {
 							autoPlay={false}
 							preload="metadata"
 						>
-							<source src={getVideoUrl()} type="video/mp4" />
+							{transformedVideoUrl && (
+								<source src={transformedVideoUrl} type="video/mp4" />
+							)}
+							<source src={video.url} />
 							{t("video-unsupported")}
 						</video>
 						{!isPlaying && (

--- a/components/feature/post/post-details.tsx
+++ b/components/feature/post/post-details.tsx
@@ -6,9 +6,11 @@ import { PostHeader } from "./post-header";
 export const PostDetails = ({
 	post,
 	children,
+	onCommentClick,
 }: {
 	post: PostWithUserAndMedias;
 	children?: React.ReactNode | null;
+	onCommentClick?: () => void;
 }) => {
 	return (
 		<article
@@ -22,6 +24,7 @@ export const PostDetails = ({
 				comments={post._count.comments}
 				postId={post.id}
 				title={post.title}
+				onCommentClick={onCommentClick}
 			/>
 			{children}
 		</article>


### PR DESCRIPTION
## Summary
Two fixes spotted on the post detail page (`/post/[id]`):

1. **Duplicate comment form** — `PostActions` had an inline `showCommentForm` toggle that rendered `PostFormComment` + `PostCommentsList` while `PostCard` already mounts those components as `PostDetails` children. Clicking the comment icon produced two identical forms and "Aucun commentaire" empty-state cards stacked. Added an `onCommentClick` prop on `PostActions`/`PostDetails`; when provided (detail page), the click focuses the permanent form via the existing `commentFormRef` instead of opening the inline toggle. Feed pages keep the original toggle behavior.
2. **Cloudinary video "Format vidéo non pris en charge"** — `post-content.tsx` used a single `<source>` with `f_mp4,vc_auto` and no fallback. `vc_auto` can fail (plan limits / source codec) which immediately fires `error` on the `<video>` and we render the error badge. Dropped `vc_auto` (plain `f_mp4`) and added the original URL as a second `<source>`, so the error state only shows once both sources fail.

## Test plan
- [ ] On `/post/[id]`, confirm only one comment form + comment list is visible after clicking the comment icon
- [ ] Confirm clicking the comment icon focuses the permanent form (textarea gets cursor)
- [ ] On the feed/home page, confirm `PostActions`' inline comment toggle still works (no regression)
- [ ] On `/post/[id]` with a Cloudinary video, confirm playback works and no "Format vidéo non pris en charge" badge is shown for previously-broken videos