### PR TITLE
feat(motion): add micro-interactions with Framer Motion

### DIFF
--- a/app/(home)/(public)/explore/explore-header.tsx
+++ b/app/(home)/(public)/explore/explore-header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AnimatePresence, motion } from "framer-motion";
 import { Search } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -49,34 +50,44 @@ export const ExploreHeader = () => {
 				</div>
 			</div>
 
-			{q && (
-				<Tabs
-					value={tab}
-					onValueChange={(value) => navigateTo(q, value)}
-					className="w-full"
-				>
-					<TabsList className="w-full justify-between h-auto bg-transparent p-0 px-4">
-						<TabsTrigger
-							value="top"
-							className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
+			<AnimatePresence>
+				{q && (
+					<motion.div
+						key="search-tabs"
+						initial={{ opacity: 0, y: -8 }}
+						animate={{ opacity: 1, y: 0 }}
+						exit={{ opacity: 0, y: -8 }}
+						transition={{ duration: 0.2, ease: "easeOut" }}
+					>
+						<Tabs
+							value={tab}
+							onValueChange={(value) => navigateTo(q, value)}
+							className="w-full"
 						>
-							{t("tabs.top")}
-						</TabsTrigger>
-						<TabsTrigger
-							value="users"
-							className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
-						>
-							{t("tabs.users")}
-						</TabsTrigger>
-						<TabsTrigger
-							value="posts"
-							className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
-						>
-							{t("tabs.posts")}
-						</TabsTrigger>
-					</TabsList>
-				</Tabs>
-			)}
+							<TabsList className="w-full justify-between h-auto bg-transparent p-0 px-4">
+								<TabsTrigger
+									value="top"
+									className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
+								>
+									{t("tabs.top")}
+								</TabsTrigger>
+								<TabsTrigger
+									value="users"
+									className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
+								>
+									{t("tabs.users")}
+								</TabsTrigger>
+								<TabsTrigger
+									value="posts"
+									className="flex-1 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-1 pb-2"
+								>
+									{t("tabs.posts")}
+								</TabsTrigger>
+							</TabsList>
+						</Tabs>
+					</motion.div>
+				)}
+			</AnimatePresence>
 		</header>
 	);
 };

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "cookies-next": "^6.1.1",
         "date-fns": "^4.1.0",
         "dotenv": "^16.6.1",
+        "framer-motion": "^12.38.0",
         "lucide-react": "^1.11.0",
         "next": "16.2.3",
         "next-intl": "^4.9.1",
@@ -971,6 +972,8 @@
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
+    "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
+
     "fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
@@ -1212,6 +1215,10 @@
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
+
+    "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/components/feature/follow/follow-button.tsx
+++ b/components/feature/follow/follow-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AnimatePresence, motion } from "framer-motion";
 import { UserCheck, UserRoundPlus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
@@ -68,13 +69,35 @@ export const FollowButton = ({
 			size={showText ? "sm" : "icon"}
 			onClick={handleToggleFollow}
 			disabled={isLoading}
+			className="relative overflow-hidden"
 		>
-			{isFollowing ? (
-				<UserCheck className="h-4 w-4" />
-			) : (
-				<UserRoundPlus className="h-4 w-4" />
-			)}
-			{showText && (isFollowing ? t("following") : t("follow"))}
+			<AnimatePresence mode="wait" initial={false}>
+				{isFollowing ? (
+					<motion.span
+						key="following"
+						initial={{ scale: 0, rotate: -30 }}
+						animate={{ scale: 1, rotate: 0 }}
+						exit={{ scale: 0, rotate: 30 }}
+						transition={{ type: "spring", stiffness: 400, damping: 18 }}
+						className="flex items-center gap-1"
+					>
+						<UserCheck className="h-4 w-4" />
+						{showText && t("following")}
+					</motion.span>
+				) : (
+					<motion.span
+						key="not-following"
+						initial={{ scale: 0, rotate: 30 }}
+						animate={{ scale: 1, rotate: 0 }}
+						exit={{ scale: 0, rotate: -30 }}
+						transition={{ type: "spring", stiffness: 400, damping: 18 }}
+						className="flex items-center gap-1"
+					>
+						<UserRoundPlus className="h-4 w-4" />
+						{showText && t("follow")}
+					</motion.span>
+				)}
+			</AnimatePresence>
 		</Button>
 	);
 };

--- a/components/feature/notifications/notification-bell.tsx
+++ b/components/feature/notifications/notification-bell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { AnimatePresence, motion } from "framer-motion";
 import { Bell } from "lucide-react";
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 import { getUnreadNotificationCount } from "@/src/query/notification.query";
 
 export function NotificationBell() {
@@ -12,18 +14,49 @@ export function NotificationBell() {
 		refetchInterval: 30000,
 	});
 
+	const prevCountRef = useRef(count);
+	const [isWiggling, setIsWiggling] = useState(false);
+
+	useEffect(() => {
+		if (count > prevCountRef.current) {
+			setIsWiggling(true);
+			const t = setTimeout(() => setIsWiggling(false), 600);
+			return () => clearTimeout(t);
+		}
+		prevCountRef.current = count;
+	}, [count]);
+
 	return (
 		<Link
 			href="/notifications"
 			className="relative inline-flex items-center justify-center w-9 h-9 rounded-full hover:bg-accent transition-colors"
 			aria-label="Notifications"
 		>
-			<Bell className="h-5 w-5" />
-			{count > 0 && (
-				<span className="absolute -top-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-destructive text-[10px] font-bold text-destructive-foreground">
-					{count >= 10 ? "9+" : count}
-				</span>
-			)}
+			<motion.div
+				animate={
+					isWiggling
+						? { rotate: [0, -18, 18, -12, 12, -6, 6, 0] }
+						: { rotate: 0 }
+				}
+				transition={{ duration: 0.55, ease: "easeInOut" }}
+			>
+				<Bell className="h-5 w-5" />
+			</motion.div>
+
+			<AnimatePresence>
+				{count > 0 && (
+					<motion.span
+						key="badge"
+						initial={{ scale: 0 }}
+						animate={{ scale: 1 }}
+						exit={{ scale: 0 }}
+						transition={{ type: "spring", stiffness: 500, damping: 20 }}
+						className="absolute -top-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-destructive text-[10px] font-bold text-destructive-foreground"
+					>
+						{count >= 10 ? "9+" : count}
+					</motion.span>
+				)}
+			</AnimatePresence>
 		</Link>
 	);
 }

--- a/components/feature/notifications/notification-bell.tsx
+++ b/components/feature/notifications/notification-bell.tsx
@@ -21,6 +21,7 @@ export function NotificationBell() {
 		if (count > prevCountRef.current) {
 			setIsWiggling(true);
 			const t = setTimeout(() => setIsWiggling(false), 600);
+			prevCountRef.current = count;
 			return () => clearTimeout(t);
 		}
 		prevCountRef.current = count;

--- a/components/feature/post/post-actions.tsx
+++ b/components/feature/post/post-actions.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AnimatePresence, motion } from "framer-motion";
 import { Bookmark, Heart, MessageCircle } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -43,6 +44,7 @@ export function PostActions({
 	const [showCommentForm, setShowCommentForm] = useState(false);
 	const [isLike, setIsLike] = useState(false);
 	const [isFavorite, setIsFavorite] = useState(false);
+	const [likeAnimKey, setLikeAnimKey] = useState(0);
 	const t = useTranslations("posts.post-actions");
 
 	const { data: commentData } = useCommentCount(postId);
@@ -78,6 +80,8 @@ export function PostActions({
 			redirectToSignIn();
 			return;
 		}
+
+		setLikeAnimKey((k) => k + 1);
 
 		try {
 			const result = await toggleLike({ postId });
@@ -135,11 +139,19 @@ export function PostActions({
 						className="h-9 w-9"
 						onClick={handleLike}
 					>
-						<Heart
-							className={cn("h-6 w-6", {
-								"fill-red-500 text-red-500": isLike,
-							})}
-						/>
+						<motion.div
+							key={likeAnimKey}
+							initial={likeAnimKey > 0 ? { scale: 1.5 } : false}
+							animate={{ scale: 1 }}
+							whileTap={{ scale: 0.75 }}
+							transition={{ type: "spring", stiffness: 400, damping: 14 }}
+						>
+							<Heart
+								className={cn("h-6 w-6", {
+									"fill-red-500 text-red-500": isLike,
+								})}
+							/>
+						</motion.div>
 					</Button>
 					<Button
 						variant="ghost"
@@ -182,15 +194,25 @@ export function PostActions({
 				</Link>
 			)}
 
-			{showCommentForm && (
-				<div className="mt-2">
-					<PostFormComment
-						postId={postId}
-						onCommentPosted={updateCommentCount}
-					/>
-					<PostCommentsList postId={postId} />
-				</div>
-			)}
+			<AnimatePresence>
+				{showCommentForm && (
+					<motion.div
+						key="inline-comments"
+						initial={{ height: 0, opacity: 0 }}
+						animate={{ height: "auto", opacity: 1 }}
+						exit={{ height: 0, opacity: 0 }}
+						transition={{ duration: 0.25, ease: "easeInOut" }}
+						style={{ overflow: "hidden" }}
+						className="mt-2"
+					>
+						<PostFormComment
+							postId={postId}
+							onCommentPosted={updateCommentCount}
+						/>
+						<PostCommentsList postId={postId} />
+					</motion.div>
+				)}
+			</AnimatePresence>
 		</div>
 	);
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -81,6 +81,7 @@ const pwa = withPWA({
 });
 
 const nextConfig: NextConfig = {
+	transpilePackages: ["framer-motion", "motion-dom", "motion-utils"],
 	images: {
 		remotePatterns: [
 			{

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"cookies-next": "^6.1.1",
 		"date-fns": "^4.1.0",
 		"dotenv": "^16.6.1",
+		"framer-motion": "^12.38.0",
 		"lucide-react": "^1.11.0",
 		"next": "16.2.3",
 		"next-intl": "^4.9.1",


### PR DESCRIPTION
## Summary
Install `framer-motion@12` and add 6 micro-interactions across key interaction points:

| Component | Animation |
|---|---|
| **Heart (like)** | Spring burst `scale 1.5→1` on like/unlike + `whileTap` squish |
| **Comment section** | `AnimatePresence` accordion `height 0→auto` + fade (feed only) |
| **Follow button** | `AnimatePresence mode="wait"` icon swap with rotation spring |
| **Notification badge** | Spring scale in/out on appear/disappear |
| **Bell** | Rotate keyframe wiggle when unread count increases |
| **Explore tabs** | Fade + slide-down `y -8→0` on first search query |

## Test plan
- [ ] Like a post — heart should burst (scale pop) then settle
- [ ] Unlike — same pop animation plays in reverse direction
- [ ] Click comment icon on feed card — section slides open/closed smoothly
- [ ] Follow/unfollow a user — icon rotates in/out with spring
- [ ] Trigger a new notification — bell wiggles, badge springs in
- [ ] Clear all notifications — badge springs out
- [ ] Type in explore search — tabs slide down; clear search — tabs slide up