### PR TITLE
feat(video): auto-pause when scrolled out of viewport

### DIFF
--- a/components/feature/post/post-content.tsx
+++ b/components/feature/post/post-content.tsx
@@ -17,6 +17,7 @@ export function PostContent({ post }: PostContentProps) {
 	const [canPlayVideo, setCanPlayVideo] = useState(true);
 	const [aspectRatio, setAspectRatio] = useState("16/9");
 	const videoRef = useRef<HTMLVideoElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		const el = videoRef.current;
@@ -33,6 +34,25 @@ export function PostContent({ post }: PostContentProps) {
 			el.removeEventListener("error", handleError);
 		};
 	}, [t]);
+
+	useEffect(() => {
+		const container = containerRef.current;
+		const el = videoRef.current;
+		if (!container || !el) return;
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (!entries[0]?.isIntersecting) {
+					el.pause();
+					setIsPlaying(false);
+				}
+			},
+			{ threshold: 0.25 },
+		);
+
+		observer.observe(container);
+		return () => observer.disconnect();
+	}, []);
 
 	const handleLoadedMetadata = () => {
 		const el = videoRef.current;
@@ -83,7 +103,11 @@ export function PostContent({ post }: PostContentProps) {
 	})();
 
 	return (
-		<div className="relative w-full overflow-hidden" style={{ aspectRatio }}>
+		<div
+			ref={containerRef}
+			className="relative w-full overflow-hidden"
+			style={{ aspectRatio }}
+		>
 			<button
 				type="button"
 				aria-label={isPlaying ? t("pause-video") : t("play-video")}


### PR DESCRIPTION
## Summary

- Adds an `IntersectionObserver` on the video container with a `0.25` threshold
- When less than 25% of the video is visible, the video automatically pauses
- Resets `isPlaying` state so the play overlay reappears correctly

## Test plan

- [ ] Play a video on the feed, scroll down past it — video should pause
- [ ] Scroll back up — play overlay should be visible again
- [ ] Works on both portrait and landscape videos