### PR TITLE
fix(ux): optimistic like, cursor-pointer, age label, messages route

### DIFF
--- a/app/(home)/(private)/messages/components/message-list.tsx
+++ b/app/(home)/(private)/messages/components/message-list.tsx
@@ -26,7 +26,7 @@ export function MessageList({ messages }: MessageListProps) {
 						type="button"
 						className="flex-1 min-w-0 text-left"
 						onClick={() => {
-							router.push(`/messages/${message.user}`);
+							router.push(`/messages/${message.userId}`);
 						}}
 					>
 						<div className="flex items-center justify-between gap-2">

--- a/app/(home)/(private)/messages/queries.ts
+++ b/app/(home)/(private)/messages/queries.ts
@@ -89,6 +89,7 @@ export async function getMessagesGroupedByUser(
 
 		const formattedMessage: Message = {
 			id: message.id,
+			userId: otherUser.id,
 			user: otherUser.name || "Unknown",
 			image:
 				otherUser.image ||

--- a/app/(home)/(private)/messages/types.ts
+++ b/app/(home)/(private)/messages/types.ts
@@ -6,6 +6,7 @@ export type MessageUser = {
 
 export type Message = {
 	id: string;
+	userId: string;
 	user: string;
 	image: string;
 	message: string;

--- a/components/feature/post/post-actions.tsx
+++ b/components/feature/post/post-actions.tsx
@@ -83,17 +83,23 @@ export function PostActions({
 
 		setLikeAnimKey((k) => k + 1);
 
+		const optimisticLike = !isLike;
+		setIsLike(optimisticLike);
+		if (optimisticLike) likePost(postId);
+		else unlikePost(postId);
+
 		try {
 			const result = await toggleLike({ postId });
-			setIsLike(result);
-
-			if (result) {
-				likePost(postId);
-			} else {
-				unlikePost(postId);
+			if (result !== optimisticLike) {
+				setIsLike(result);
+				if (result) likePost(postId);
+				else unlikePost(postId);
 			}
 		} catch (error) {
 			console.error("Error toggling like:", error);
+			setIsLike(!optimisticLike);
+			if (!optimisticLike) likePost(postId);
+			else unlikePost(postId);
 		}
 	};
 
@@ -104,11 +110,15 @@ export function PostActions({
 			return;
 		}
 
+		const optimisticFavorite = !isFavorite;
+		setIsFavorite(optimisticFavorite);
+
 		try {
 			const result = await toggleFavorite({ postId });
-			setIsFavorite(result);
+			if (result !== optimisticFavorite) setIsFavorite(result);
 		} catch (error) {
 			console.error("Error toggling favorite:", error);
+			setIsFavorite(!optimisticFavorite);
 		}
 	};
 

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer",
 	{
 		variants: {
 			variant: {

--- a/messages/en.json
+++ b/messages/en.json
@@ -480,7 +480,7 @@
 				"localisation": "City",
 				"position": "Position",
 				"foot": "Preferred foot",
-				"age": "Age",
+				"age": "years old",
 				"send-message": "Send a message"
 			},
 			"search": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -480,7 +480,7 @@
 				"localisation": "Ville",
 				"position": "Poste",
 				"foot": "Pied préféré",
-				"age": "Âge",
+				"age": "ans",
 				"send-message": "Envoyer un message"
 			},
 			"search": {


### PR DESCRIPTION
## Summary

- **Optimistic UI on like/favorite** — heart and bookmark flip immediately on click; reconcile with server response, revert on error. Removes ~500ms-1s perceived lag from the Server Action round-trip.
- **`cursor-pointer` on Button base class** — every button in the app now shows pointer cursor on hover.
- **i18n age label** — `Âge`/`Age` → `ans`/`years old` so the badge reads "30 ans" / "30 years old" instead of "30 Âge".
- **Messages route fix** — inbox MessageList was navigating to `/messages/{display-name}`, breaking the chat page query. Now uses the user's ID.

## Test plan

- [ ] Click like on a post — heart fills red instantly
- [ ] Click bookmark — fills instantly
- [ ] Hover any button — pointer cursor visible
- [ ] User profile shows "30 ans" not "30 Âge"
- [ ] Click a conversation in the messages inbox — chat loads with messages