### PR TITLE
feat: WebP conversion, Oswald font, full-width edit profile

### DIFF
--- a/app/(home)/(private)/profile/edit-user/page.tsx
+++ b/app/(home)/(private)/profile/edit-user/page.tsx
@@ -27,7 +27,7 @@ export default function EditUserPage() {
 	return (
 		<>
 			<PageHeader title={t("edit-profile")} backLink="/profile" />
-			<Card className="mx-auto max-w-sm shadow-none border-none">
+			<Card className="w-full shadow-none border-none">
 				<CardHeader>
 					<CardDescription>{t("enter-email-to-edit-profile")}</CardDescription>
 				</CardHeader>

--- a/app/(home)/(private)/profile/edit-user/user-form.tsx
+++ b/app/(home)/(private)/profile/edit-user/user-form.tsx
@@ -98,7 +98,7 @@ export const UserForm = ({ userId }: { userId: string }) => {
 				</Alert>
 			)}
 
-			<InputLayout className="grid w-full max-w-sm items-center gap-1.5 mb-4">
+			<InputLayout>
 				<Label htmlFor="email">{t("email")}</Label>
 				<Input
 					type="email"

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,6 +15,13 @@
 	::file-selector-button {
 		border-color: var(--border);
 	}
+
+	h1,
+	h2,
+	h3,
+	h4 {
+		font-family: var(--font-oswald);
+	}
 }
 
 :root {

--- a/components/feature/post/post-content.tsx
+++ b/components/feature/post/post-content.tsx
@@ -3,6 +3,7 @@ import { Play } from "lucide-react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
+import { toCloudinaryWebP } from "@/src/lib/cloudinary";
 import type { PostWithUserAndMedias } from "@/src/types/post.types";
 
 interface PostContentProps {
@@ -121,7 +122,7 @@ export function PostContent({ post }: PostContentProps) {
 							muted={false}
 							loop
 							className="w-full h-full object-contain"
-							poster={image?.url}
+							poster={toCloudinaryWebP(image?.url)}
 							controls={isPlaying}
 							autoPlay={false}
 							preload="metadata"

--- a/components/feature/post/video-uploader.tsx
+++ b/components/feature/post/video-uploader.tsx
@@ -13,6 +13,7 @@ import {
 } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { convertToWebP } from "@/src/lib/cloudinary";
 
 interface VideoUploaderProps {
 	onVideoChange: (file: File | null) => void;
@@ -114,10 +115,11 @@ export function VideoUploader({
 	);
 
 	const handleThumbnailSelect = useCallback(
-		(e: React.ChangeEvent<HTMLInputElement>) => {
+		async (e: React.ChangeEvent<HTMLInputElement>) => {
 			const file = e.target.files?.[0];
 			if (file) {
-				onThumbnailChange(file);
+				const webpFile = await convertToWebP(file);
+				onThumbnailChange(webpFile);
 				setSelectedThumbnailIndex(null);
 				setShowThumbnailOverride(false);
 			}
@@ -150,8 +152,8 @@ export function VideoUploader({
 					fetch(thumbnails[0])
 						.then((r) => r.blob())
 						.then((blob) => {
-							const file = new File([blob], "thumbnail-auto.jpg", {
-								type: "image/jpeg",
+							const file = new File([blob], "thumbnail-auto.webp", {
+								type: "image/webp",
 							});
 							onThumbnailChange(file);
 							setSelectedThumbnailIndex(0);
@@ -169,7 +171,7 @@ export function VideoUploader({
 			canvas.width = videoElement.videoWidth;
 			canvas.height = videoElement.videoHeight;
 			ctx.drawImage(videoElement, 0, 0);
-			thumbnails.push(canvas.toDataURL("image/jpeg", 0.8));
+			thumbnails.push(canvas.toDataURL("image/webp", 0.85));
 			index++;
 			captureFrame();
 		};
@@ -181,8 +183,8 @@ export function VideoUploader({
 		async (dataUrl: string, index: number) => {
 			const response = await fetch(dataUrl);
 			const blob = await response.blob();
-			const file = new File([blob], `thumbnail-${index}.jpg`, {
-				type: "image/jpeg",
+			const file = new File([blob], `thumbnail-${index}.webp`, {
+				type: "image/webp",
 			});
 			onThumbnailChange(file);
 			setSelectedThumbnailIndex(index);

--- a/components/layouts/input-layout.tsx
+++ b/components/layouts/input-layout.tsx
@@ -1,5 +1,5 @@
 import { twx } from "@/lib/twx";
 
 export const InputLayout = twx.div(() => [
-	"grid w-full max-w-sm items-center gap-1.5 mb-4",
+	"grid w-full items-center gap-1.5 mb-4",
 ]);

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -2,8 +2,8 @@
 
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import * as React from "react";
-
 import { cn } from "@/lib/utils";
+import { toCloudinaryWebP } from "@/src/lib/cloudinary";
 
 const Avatar = React.forwardRef<
 	React.ElementRef<typeof AvatarPrimitive.Root>,
@@ -23,10 +23,11 @@ Avatar.displayName = AvatarPrimitive.Root.displayName;
 const AvatarImage = React.forwardRef<
 	React.ElementRef<typeof AvatarPrimitive.Image>,
 	React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
->(({ className, ...props }, ref) => (
+>(({ className, src, ...props }, ref) => (
 	<AvatarPrimitive.Image
 		ref={ref}
 		className={cn("aspect-square h-full w-full", className)}
+		src={toCloudinaryWebP(src as string) ?? src}
 		{...props}
 	/>
 ));

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer",
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer font-oswald",
 	{
 		variants: {
 			variant: {

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -42,6 +42,8 @@ export async function convertToWebP(file: File, quality = 0.85): Promise<File> {
 
 		const name = file.name.replace(/\.[^/.]+$/, ".webp");
 		return new File([blob], name, { type: "image/webp" });
+	} catch {
+		return file;
 	} finally {
 		URL.revokeObjectURL(url);
 	}

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,0 +1,48 @@
+/**
+ * Adds f_webp,q_auto transformations to Cloudinary image URLs.
+ * Non-Cloudinary URLs are returned unchanged.
+ */
+export function toCloudinaryWebP(
+	url: string | null | undefined,
+): string | undefined {
+	if (!url) return undefined;
+	if (!url.includes("res.cloudinary.com") || !url.includes("/upload/"))
+		return url;
+	return url.replace("/upload/", "/upload/f_webp,q_auto/");
+}
+
+/**
+ * Converts an image File to WebP client-side using Canvas.
+ * Falls back to the original file if conversion fails or is unsupported.
+ */
+export async function convertToWebP(file: File, quality = 0.85): Promise<File> {
+	if (file.type === "image/webp") return file;
+	if (!file.type.startsWith("image/")) return file;
+
+	const url = URL.createObjectURL(file);
+	try {
+		const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+			const image = new window.Image();
+			image.onload = () => resolve(image);
+			image.onerror = reject;
+			image.src = url;
+		});
+
+		const canvas = document.createElement("canvas");
+		canvas.width = img.naturalWidth;
+		canvas.height = img.naturalHeight;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return file;
+		ctx.drawImage(img, 0, 0);
+
+		const blob = await new Promise<Blob | null>((resolve) =>
+			canvas.toBlob(resolve, "image/webp", quality),
+		);
+		if (!blob) return file;
+
+		const name = file.name.replace(/\.[^/.]+$/, ".webp");
+		return new File([blob], name, { type: "image/webp" });
+	} finally {
+		URL.revokeObjectURL(url);
+	}
+}


### PR DESCRIPTION
## Summary

**WebP image optimization**
- `AvatarImage` (Radix → native `<img>`, not Next.js-optimized) now requests `f_webp,q_auto` from Cloudinary URLs; non-Cloudinary URLs (Google/GitHub/dicebear) pass through unchanged.
- Video `poster` thumbnails request `f_webp,q_auto` too.
- At upload: auto-generated video thumbnails (canvas) produce `image/webp`; user-uploaded custom thumbnails are converted to WebP client-side via `convertToWebP()` before hitting Cloudinary. Falls back to original file if the browser can't encode WebP.
- New util: `src/lib/cloudinary.ts` (`toCloudinaryWebP`, `convertToWebP`).

**Typography**
- Oswald font applied to `h1`-`h4` headings (globals.css `@layer base`) and the Button base class.

**Full-width edit profile**
- Removed `max-w-sm` from the edit-profile `Card` wrapper and from `InputLayout` so the form spans the page width.

## Test plan

- [ ] Avatars load as WebP (check Network tab → `f_webp` in Cloudinary URLs)
- [ ] Video thumbnail loads as WebP
- [ ] Upload a new video → check the thumbnail sent to Cloudinary is `.webp`
- [ ] Upload a custom JPEG thumbnail → it gets converted to WebP
- [ ] Headings and buttons render in Oswald
- [ ] Edit profile form spans full width on mobile and desktop